### PR TITLE
chore(rename): Replace references to redwood with redmix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,7 +22,7 @@ body:
         What commands do we need to run?
         Are there any packages that we need to install?
         What does the `schema.prisma` need to look like?
-        Maybe include a link to a GitHub repo or a Gitpod snapshot? ([Instructions here](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#Creating-a-reproduction-to-include-with-issues).)
+        Maybe include a link to a GitHub repo or a Gitpod snapshot? ([Instructions here](https://github.com/redmix-run/redmix/blob/main/CONTRIBUTING.md#Creating-a-reproduction-to-include-with-issues).)
 
 
         While this field is optional,

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -46,9 +46,9 @@ body:
 
         Lastly, consider reading some great examples:
 
-        - [Prerender proposal](https://community.redwoodjs.com/t/prerender-proposal/849)
-        - [Optional path parameters](https://github.com/redwoodjs/redwood/issues/2429)
-        - [Multitenant support](https://github.com/redwoodjs/redwood/issues/5821)
+        - [Prerender proposal](https://community.redmix-run.com/t/prerender-proposal/849)
+        - [Optional path parameters](https://github.com/redmix-run/redmix/issues/2429)
+        - [Multitenant support](https://github.com/redmix-run/redmix/issues/5821)
     validations:
       required: true
 

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -9,7 +9,7 @@ import { codeChanges } from './cases/code_changes.mjs'
 import { rscChanged } from './cases/rsc.mjs'
 import { ssrChanged } from './cases/ssr.mjs'
 
-const BASE_URL = 'https://api.github.com/repos/redwoodjs/redwood'
+const BASE_URL = 'https://api.github.com/repos/redmix-run/redmix'
 
 const getPrNumber = () => {
   // Example GITHUB_REF refs/pull/9544/merge
@@ -71,7 +71,7 @@ async function getLatestCompletedWorkflowRun(branchName) {
 
   // 24294187 is the ID of the CI workflow (ci.yml). If it changes, or you want
   // to use a different workflow, go to
-  // https://api.github.com/repos/redwoodjs/redwood/actions/workflows to get a
+  // https://api.github.com/repos/redmix-run/redmix/actions/workflows to get a
   // list of all workflows and their IDs
   const workflowId = '24294187'
   const url = `${BASE_URL}/actions/workflows/${workflowId}/runs?branch=${branchName}`
@@ -211,12 +211,12 @@ async function fetchJson(url, retries = 0) {
 // commits we've already run CI for
 //
 // 1. Get the PR branch name
-//    https://api.github.com/repos/redwoodjs/redwood/pulls/10374  .head.ref
+//    https://api.github.com/repos/redmix-run/redmx/pulls/10374  .head.ref
 // 2. Get CI workflow runs for that branch
-//    https://api.github.com/repos/redwoodjs/redwood/actions/workflows/24294187/runs?branch=tobbe-redirect-docs
+//    https://api.github.com/repos/redmix-run/redmx/actions/workflows/24294187/runs?branch=tobbe-redirect-docs
 // 3. Get the `updated_at` timestamp for the newest completed run (`status` === 'completed')
 // 4. Get all commits for the PR
-//      https://api.github.com/repos/redwoodjs/redwood/pulls/10374/commits
+//      https://api.github.com/repos/redmix-run/redmx/pulls/10374/commits
 // 5. Filter out all commits that are newer than the timestamp from step 3
 // 6. Gather up all files changed in the commits from step 5
 // 7. Use those files in the checks we do in this action

--- a/.github/actions/telemetry_check/check.mjs
+++ b/.github/actions/telemetry_check/check.mjs
@@ -51,7 +51,7 @@ try {
         process.exit(1)
       }
       exitCode = await exec(
-        `yarn --cwd ../project-for-telemetry node ../redwood/packages/cli/dist/index.js info`,
+        `yarn --cwd ../project-for-telemetry node ../redmix/packages/cli/dist/index.js info`,
       )
       if (exitCode) {
         process.exit(1)

--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   detect-changes:
-    if: github.repository == 'redwoodjs/redwood'
+    if: github.repository == 'redmix-run/redmix'
     name: 🔍 Detect changes
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   detect-changes:
-    if: github.repository == 'redwoodjs/redwood'
+    if: github.repository == 'redmix-run/redmix'
     name: 🔍 Detect changes
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -19,7 +19,7 @@ permissions: {}
 jobs:
   publish-canary:
     name: 🦜 Publish Canary
-    if: github.repository == 'redwoodjs/redwood'
+    if: github.repository == 'redmix-run/redmix'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.value }}

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -19,7 +19,7 @@ permissions: {}
 jobs:
   check-git-tags:
     name: 🏷 Check git tags
-    if: github.repository == 'redwoodjs/redwood'
+    if: github.repository == 'redmix-run/redmix'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/__fixtures__/test-project/api/src/lib/auth.ts
+++ b/__fixtures__/test-project/api/src/lib/auth.ts
@@ -108,7 +108,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -58,7 +58,7 @@ const config: Config = {
           position: 'left',
         },
         {
-          href: 'https://github.com/redwoodjs/redwood',
+          href: 'https://github.com/redmix-run/redmix',
           position: 'right',
           className: 'github-logo',
           'aria-label': 'GitHub repository',
@@ -106,7 +106,7 @@ const config: Config = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com/redwoodjs/redwood',
+              href: 'https://github.com/redmix-run/redmix',
             },
           ],
         },
@@ -121,7 +121,7 @@ const config: Config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // ? — blob? tree?
-          editUrl: 'https://github.com/redwoodjs/redwood/blob/main/docs', // base path for repo edit pages
+          editUrl: 'https://github.com/redmix-run/redmix/blob/main/docs', // base path for repo edit pages
           editCurrentVersion: true,
           remarkPlugins: [autoImportTabs, fileExtSwitcher],
           versions: {

--- a/docs/ignore_build.mjs
+++ b/docs/ignore_build.mjs
@@ -20,7 +20,7 @@ async function main() {
   }
 
   // Query the GithHub API to get the changed files in the PR
-  const url = `https://api.github.com/repos/redwoodjs/redwood/pulls/${process.env.REVIEW_ID}/files?per_page=100`
+  const url = `https://api.github.com/repos/redmix-run/redmix/pulls/${process.env.REVIEW_ID}/files?per_page=100`
   const resp = await fetch(url, {
     headers: {
       Authorization: `Bearer ${process.env.RW_GITHUB_TOKEN}`,

--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/adapters/fastify/web"
   },
   "license": "MIT",

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -4,7 +4,7 @@
   "description": "Redwood's HTTP server for Serverless Functions",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/api-server"
   },
   "license": "MIT",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/auth0/api/package.json
+++ b/packages/auth-providers/auth0/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/auth0/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/auth0/setup/package.json
+++ b/packages/auth-providers/auth0/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/auth0/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/auth0/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/auth0/setup/src/templates/api/lib/auth.ts.template
@@ -18,7 +18,7 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * fields to the return object only once you've decided they are safe to be seen
  * if someone were to open the Web Inspector in their browser.
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  *
  * @param decoded - The decoded access token containing user info and JWT
  *   claims like `sub`. Note, this could be null.
@@ -113,7 +113,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} - If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/auth0/web"
   },
   "license": "MIT",

--- a/packages/auth-providers/azureActiveDirectory/api/package.json
+++ b/packages/auth-providers/azureActiveDirectory/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/azureActiveDirectory/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/azureActiveDirectory/setup/package.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/azureActiveDirectory/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/azureActiveDirectory/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/templates/api/lib/auth.ts.template
@@ -18,7 +18,7 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * fields to the return object only once you've decided they are safe to be seen
  * if someone were to open the Web Inspector in their browser.
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  *
  * @param decoded - The decoded access token containing user info and JWT
  *   claims like `sub`. Note, this could be null.
@@ -113,7 +113,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/azureActiveDirectory/web"
   },
   "license": "MIT",

--- a/packages/auth-providers/clerk/api/package.json
+++ b/packages/auth-providers/clerk/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/clerk/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/clerk/setup/package.json
+++ b/packages/auth-providers/clerk/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/clerk/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/clerk/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/clerk/setup/src/templates/api/lib/auth.ts.template
@@ -12,7 +12,7 @@ import { logger } from 'src/lib/logger'
  * @param { APIGatewayEvent event, Context context } - An object which contains information from the invoker
  * such as headers and cookies, and the context information about the invocation such as IP Address
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const getCurrentUser = async (
   decoded,
@@ -105,7 +105,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/clerk/web"
   },
   "license": "MIT",

--- a/packages/auth-providers/custom/setup/package.json
+++ b/packages/auth-providers/custom/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/custom/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/custom/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/custom/setup/src/templates/api/lib/auth.ts.template
@@ -18,7 +18,7 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * fields to the return object only once you've decided they are safe to be seen
  * if someone were to open the Web Inspector in their browser.
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  *
  * @param decoded - The decoded access token containing user info and JWT
  *   claims like `sub`. Note, this could be null.
@@ -113,7 +113,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} - If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/dbAuth/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/dbAuth/middleware"
   },
   "license": "MIT",

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/dbAuth/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/dbAuth/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/api/lib/auth.ts.template
@@ -108,7 +108,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/dbAuth/web"
   },
   "license": "MIT",

--- a/packages/auth-providers/firebase/api/package.json
+++ b/packages/auth-providers/firebase/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/firebase/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/firebase/setup/package.json
+++ b/packages/auth-providers/firebase/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/firebase/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/firebase/web"
   },
   "license": "MIT",

--- a/packages/auth-providers/netlify/api/package.json
+++ b/packages/auth-providers/netlify/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/netlify/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/netlify/setup/package.json
+++ b/packages/auth-providers/netlify/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/netlify/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/netlify/web"
   },
   "license": "MIT",

--- a/packages/auth-providers/supabase/api/package.json
+++ b/packages/auth-providers/supabase/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/supabase/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/supabase/middleware"
   },
   "license": "MIT",

--- a/packages/auth-providers/supabase/setup/package.json
+++ b/packages/auth-providers/supabase/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/supabase/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/supabase/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/supabase/setup/src/templates/api/lib/auth.ts.template
@@ -23,7 +23,7 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * fields to the return object only once you've decided they are safe to be seen
  * if someone were to open the Web Inspector in their browser.
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  *
  * @returns RedwoodUser
  */
@@ -115,7 +115,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} - If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/supabase/web"
   },
   "license": "MIT",

--- a/packages/auth-providers/supertokens/api/package.json
+++ b/packages/auth-providers/supertokens/api/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/supertokens/api"
   },
   "license": "MIT",

--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/supertokens/setup"
   },
   "license": "MIT",

--- a/packages/auth-providers/supertokens/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/supertokens/setup/src/templates/api/lib/auth.ts.template
@@ -23,7 +23,7 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * fields to the return object only once you've decided they are safe to be seen
  * if someone were to open the Web Inspector in their browser.
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  *
  * @returns RedwoodUser
  */
@@ -115,7 +115,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} - If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth-providers/supertokens/web"
   },
   "license": "MIT",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/auth"
   },
   "license": "MIT",

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/babel-config"
   },
   "license": "MIT",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/cli-helpers"
   },
   "license": "MIT",

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/cli-packages/dataMigrate"
   },
   "license": "MIT",

--- a/packages/cli-packages/storybook-vite/package.json
+++ b/packages/cli-packages/storybook-vite/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/cli-packages/storybook-vite"
   },
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "The Redwood Command Line",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/cli"
   },
   "license": "MIT",

--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -363,7 +363,7 @@ export const handler = async ({ force, verbose }) => {
         task: async () => {
           // Fetch the web package.json from the main branch
           const canaryWebPackageJsonUrl =
-            'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/templates/ts/web/package.json'
+            'https://raw.githubusercontent.com/redmix-run/redmix/main/packages/create-redwood-app/templates/ts/web/package.json'
           const response = await fetch(canaryWebPackageJsonUrl)
           const canaryPackageJson = await response.json()
 

--- a/packages/cli/src/commands/setup/deploy/templates/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/templates/baremetal.js
@@ -50,7 +50,7 @@ freeSpaceRequired = 2048
 # agentForward = true
 # sides = ["api"]
 # path = "/var/www/app"
-# repo = "git@github.com:redwoodjs/redwood.git"
+# repo = "git@github.com:redmix-run/redmix.git"
 # branch = "main"
 # processNames = ["api"]
 #
@@ -60,7 +60,7 @@ freeSpaceRequired = 2048
 # agentForward = true
 # sides = ["web"]
 # path = "/var/www/app"
-# repo = "git@github.com:redwoodjs/redwood.git"
+# repo = "git@github.com:redmix-run/redmix.git"
 # branch = "main"
 # migrate = false # only one server in a cluster needs to migrate
 # processNames = ["web"]

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -60,7 +60,7 @@ export const builder = (yargs) => {
         'https://redwoodjs.com/docs/cli-commands#upgrade',
       )}.\nAnd the ${terminalLink(
         'GitHub releases page',
-        'https://github.com/redwoodjs/redwood/releases',
+        'https://github.com/redmix-run/redmix/releases',
       )} for more information on the current release.`,
     )
 }
@@ -191,7 +191,7 @@ export const handler = async ({ dryRun, tag, verbose, dedupe, yes }) => {
                 `https://community.redwoodjs.com/c/announcements/releases-and-upgrade-guides/`,
               )}\n   ❖ ${terminalLink(
                 `GitHub Release notes`,
-                `https://github.com/redwoodjs/redwood/releases`, // intentionally not linking to specific version
+                `https://github.com/redmix-run/redmix/releases`, // intentionally not linking to specific version
               )} \n\n`,
             )
           }
@@ -353,15 +353,15 @@ async function updatePackageVersionsFromTemplate(ctx, { dryRun, verbose }) {
   const packageJsons = [
     {
       basePath: getPaths().base,
-      url: 'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/templates/ts/package.json',
+      url: 'https://raw.githubusercontent.com/redmix-run/redmix/main/packages/create-redwood-app/templates/ts/package.json',
     },
     {
       basePath: getPaths().api.base,
-      url: 'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/templates/ts/api/package.json',
+      url: 'https://raw.githubusercontent.com/redmix-run/redmix/main/packages/create-redwood-app/templates/ts/api/package.json',
     },
     {
       basePath: getPaths().web.base,
-      url: 'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/templates/ts/web/package.json',
+      url: 'https://raw.githubusercontent.com/redmix-run/redmix/main/packages/create-redwood-app/templates/ts/web/package.json',
     },
   ]
 
@@ -433,7 +433,7 @@ async function downloadYarnPatches(ctx, { dryRun, verbose }) {
     process.env.REDWOOD_GITHUB_TOKEN
 
   const res = await fetch(
-    'https://api.github.com/repos/redwoodjs/redwood/git/trees/main?recursive=1',
+    'https://api.github.com/repos/redmix-run/redmix/git/trees/main?recursive=1',
     {
       headers: {
         Authorization: githubToken ? `Bearer ${githubToken}` : undefined,

--- a/packages/cli/src/lib/exit.js
+++ b/packages/cli/src/lib/exit.js
@@ -15,7 +15,7 @@ const DEFAULT_ERROR_EPILOGUE = [
   )}`,
   ` - Think you've found a bug? Open an issue on our ${terminalLink(
     'GitHub',
-    'https://github.com/redwoodjs/redwood',
+    'https://github.com/redmix-run/redmix',
   )}`,
 ].join('\n')
 

--- a/packages/cli/src/lib/updateCheck.js
+++ b/packages/cli/src/lib/updateCheck.js
@@ -195,7 +195,7 @@ function getUpdateMessage() {
     }
   })
   message +=
-    '\n\n See release notes at: https://github.com/redwoodjs/redwood/releases '
+    '\n\n See release notes at: https://github.com/redmix-run/redmix/releases '
   message = message.replace('#REPLACEME#', updateCount > 1 ? ' -t [tag]' : '')
 
   return boxen(message, {

--- a/packages/cli/src/rwfw.js
+++ b/packages/cli/src/rwfw.js
@@ -16,7 +16,7 @@ const RWFW_PATH =
 
 if (!RWFW_PATH) {
   console.error('Error: You must specify the path to Redwood Framework')
-  console.error('Usage: `RWFW_PATH=~/gh/redwoodjs/redwood yarn rwfw <command>')
+  console.error('Usage: `RWFW_PATH=~/gh/redmix-run/redmix yarn rwfw <command>')
   process.exit(1)
 }
 
@@ -24,7 +24,7 @@ if (!fs.existsSync(RWFW_PATH)) {
   console.error(
     `Error: The specified path to Redwood Framework (${RWFW_PATH}) does not exist.`,
   )
-  console.error('Usage: `RWFW_PATH=~/gh/redwoodjs/redwood yarn rwfw <command>')
+  console.error('Usage: `RWFW_PATH=~/gh/redmix-run/redmix yarn rwfw <command>')
   process.exit(1)
 }
 

--- a/packages/cli/src/testLib/fetchFileFromTemplate.ts
+++ b/packages/cli/src/testLib/fetchFileFromTemplate.ts
@@ -5,7 +5,7 @@ import { fetch } from '@whatwg-node/fetch'
  * @param file should be something like 'prettier.config.js', 'api/src/index.ts', 'web/src/index.ts'
  */
 export default async function fetchFileFromTemplate(tag: string, file: string) {
-  const URL = `https://raw.githubusercontent.com/redwoodjs/redwood/${tag}/packages/create-redwood-app/template/${file}`
+  const URL = `https://raw.githubusercontent.com/redmix-run/redmix/${tag}/packages/create-redwood-app/template/${file}`
   const res = await fetch(URL)
   return res.text()
 }

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -4,7 +4,7 @@
   "description": "Codemods to ease upgrading a RedwoodJS Project",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/codemods"
   },
   "license": "MIT",

--- a/packages/codemods/src/codemods/v2.x.x/configureFastify/configureFastify.yargs.ts
+++ b/packages/codemods/src/codemods/v2.x.x/configureFastify/configureFastify.yargs.ts
@@ -42,7 +42,7 @@ export const handler = () => {
       setOutput('All done!')
     } else {
       const res = await fetch(
-        'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/server.config.js',
+        'https://raw.githubusercontent.com/redmix-run/redmix/main/packages/create-redwood-app/template/api/server.config.js',
       )
       const text = await res.text()
 

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
@@ -10,7 +10,7 @@ export const updateGraphqlConfig = async () => {
     // TODO: Have to come back here to update the URL when we have a more
     // stable location than main
     // 'https://raw.githubusercontent.com/redwoodjs/redwood/release/major/v7.0.0/packages/create-redwood-app/templates/ts/graphql.config.js'
-    'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/templates/ts/graphql.config.js',
+    'https://raw.githubusercontent.com/redmix-run/redmix/main/packages/create-redwood-app/templates/ts/graphql.config.js',
   )
   const text = await res.text()
   fs.writeFileSync(path.join(getPaths().base, 'graphql.config.js'), text)

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/context"
   },
   "license": "MIT",

--- a/packages/cookie-jar/package.json
+++ b/packages/cookie-jar/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/cookie-jar"
   },
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "Foundational packages and config required to build RedwoodJS.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/core"
   },
   "license": "MIT",

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/create-redwood-app"
   },
   "license": "MIT",

--- a/packages/create-redwood-rsc-app/package.json
+++ b/packages/create-redwood-rsc-app/package.json
@@ -4,7 +4,7 @@
   "description": "Quickstart for a RedwoodJS React Server Components App",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/create-redwood-rsc-app"
   },
   "license": "MIT",

--- a/packages/create-redwood-rsc-app/src/download.ts
+++ b/packages/create-redwood-rsc-app/src/download.ts
@@ -8,7 +8,7 @@ import type { Config } from './config.js'
 export async function downloadTemplate(config: Config) {
   console.log('📥 Downloading RedwoodJS RSC template')
 
-  const url = 'https://github.com/redwoodjs/redwood/archive/refs/heads/main.zip'
+  const url = 'https://github.com/redmix-run/redmix/archive/refs/heads/main.zip'
 
   const tmpDir = path.join(
     os.tmpdir(),

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/eslint-config"
   },
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/eslint-plugin"
   },
   "license": "MIT",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/forms"
   },
   "license": "MIT",

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/framework-tools"
   },
   "license": "MIT",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/graphql-server"
   },
   "license": "MIT",

--- a/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
+++ b/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
@@ -28,7 +28,7 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * fields to the return object only once you've decided they are safe to be seen
  * if someone were to open the Web Inspector in their browser.
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  *
  * @returns RedwoodUser
  */
@@ -123,7 +123,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  * @throws {@link ForbiddenError} - If the currentUser is not allowed due to role permissions
  *
- * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
+ * @see https://github.com/redmix-run/redmix/tree/main/packages/auth for examples
  */
 export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   if (!isAuthenticated()) {

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/internal"
   },
   "license": "MIT",

--- a/packages/internal/src/__tests__/fixtures/nestedPages/web/src/layouts/MainLayout/MainLayout.tsx
+++ b/packages/internal/src/__tests__/fixtures/nestedPages/web/src/layouts/MainLayout/MainLayout.tsx
@@ -71,7 +71,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
               <div className="ml-4">
                 <a
                   className="rounded-full px-2 py-1 bg-orange-200 hover:bg-orange-300 text-orange-600 hover:text-orange-700 text-xs font-mono font-normal no-underline transition duration-100"
-                  href="https://github.com/redwoodjs/redwood/releases"
+                  href="https://github.com/redmix-run/redmix/releases"
                   title="Go to Redwood's Releases"
                 >
                   v1.0
@@ -256,7 +256,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
                 <li className="ml-4">
                   <a
                     className="block flex no-underline"
-                    href="https://github.com/redwoodjs/redwood"
+                    href="https://github.com/redmix-run/redmix"
                     title="Go to Redwood's GitHub repo"
                   >
                     <div className="flex items-center pt-[1px] text-xs font-semibold bg-orange-600 text-orange-100 px-2 rounded-l">
@@ -270,7 +270,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
                 <li className="mr-3">
                   <a
                     className="block w-6"
-                    href="https://github.com/redwoodjs/redwood"
+                    href="https://github.com/redmix-run/redmix"
                     title="Go to Redwood's GitHub repo"
                   >
                     <svg

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/jobs"
   },
   "license": "MIT",

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/mailer/core"
   },
   "license": "MIT",

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/mailer/handlers/in-memory"
   },
   "license": "MIT",

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/mailer/handlers/nodemailer"
   },
   "license": "MIT",

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/mailer/handlers/resend"
   },
   "license": "MIT",

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/mailer/handlers/studio"
   },
   "license": "MIT",

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/mailer/renderers/mjml-react"
   },
   "license": "MIT",

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/mailer/renderers/react-email"
   },
   "license": "MIT",

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/ogimage-gen"
   },
   "license": "MIT",

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -4,7 +4,7 @@
   "description": "RedwoodJS prerender",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/prerender"
   },
   "license": "MIT",

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/project-config"
   },
   "license": "MIT",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/realtime"
   },
   "license": "MIT",

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/record"
   },
   "license": "MIT",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/router"
   },
   "license": "MIT",

--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -484,7 +484,7 @@ export const SplashPage = ({
               <div className="social">
                 <a
                   className="social-link"
-                  href="https://github.com/redwoodjs/redwood"
+                  href="https://github.com/redmix-run/redmix"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="Go to RedwoodJS GitHub repo"
@@ -543,7 +543,7 @@ export const SplashPage = ({
                 <>
                   RedwoodJS version{' '}
                   <a
-                    href="https://github.com/redwoodjs/redwood/releases"
+                    href="https://github.com/redmix-run/redmix/releases"
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/packages/server-store/package.json
+++ b/packages/server-store/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/server-store"
   },
   "license": "MIT",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/storage"
   },
   "license": "MIT",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -9,11 +9,11 @@
     "Vite"
   ],
   "bugs": {
-    "url": "git+https://github.com/redwoodjs/redwood/issues"
+    "url": "git+https://github.com/redmix-run/redmix/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/storybook"
   },
   "license": "MIT",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -4,7 +4,7 @@
   "description": "noun: the arrangement of and relations between the parts or elements of something complex",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/structure"
   },
   "license": "MIT",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/telemetry"
   },
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -4,7 +4,7 @@
   "description": "Tools, wrappers and configuration for testing a Redwood project.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/testing"
   },
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/tui"
   },
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,7 +4,7 @@
   "description": "Vite configuration package for Redwood",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/vite"
   },
   "license": "MIT",

--- a/packages/vite/src/build/__tests__/fixtures/nestedPages/web/src/layouts/MainLayout/MainLayout.tsx
+++ b/packages/vite/src/build/__tests__/fixtures/nestedPages/web/src/layouts/MainLayout/MainLayout.tsx
@@ -71,7 +71,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
               <div className="ml-4">
                 <a
                   className="rounded-full px-2 py-1 bg-orange-200 hover:bg-orange-300 text-orange-600 hover:text-orange-700 text-xs font-mono font-normal no-underline transition duration-100"
-                  href="https://github.com/redwoodjs/redwood/releases"
+                  href="https://github.com/redmix-run/redmix/releases"
                   title="Go to Redwood's Releases"
                 >
                   v1.0
@@ -256,7 +256,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
                 <li className="ml-4">
                   <a
                     className="block flex no-underline"
-                    href="https://github.com/redwoodjs/redwood"
+                    href="https://github.com/redmix-run/redmix"
                     title="Go to Redwood's GitHub repo"
                   >
                     <div className="flex items-center pt-[1px] text-xs font-semibold bg-orange-600 text-orange-100 px-2 rounded-l">
@@ -270,7 +270,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
                 <li className="mr-3">
                   <a
                     className="block w-6"
-                    href="https://github.com/redwoodjs/redwood"
+                    href="https://github.com/redmix-run/redmix"
                     title="Go to Redwood's GitHub repo"
                   >
                     <svg

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -4,7 +4,7 @@
   "description": "Redwood's server for the Web side",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/web-server"
   },
   "license": "MIT",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redwoodjs/redwood.git",
+    "url": "git+https://github.com/redmix-run/redmix.git",
     "directory": "packages/web"
   },
   "license": "MIT",

--- a/tasks/changesets/changesetsHelpers.mts
+++ b/tasks/changesets/changesetsHelpers.mts
@@ -50,7 +50,7 @@ export async function resolveArgv() {
     const currentBranch = await getStdout($`git branch --show-current`)
 
     const url =
-      'https://api.github.com/repos/redwoodjs/redwood/pulls?state=open&sort=updated&direction=desc&per_page=100'
+      'https://api.github.com/repos/redmix-run/redmix/pulls?state=open&sort=updated&direction=desc&per_page=100'
     const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${getGitHubToken()}`,

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -174,7 +174,7 @@ module.exports = defineConfig({
     enforceFieldsWithValuesOnAllWorkspaces(ctx, {
       license: 'MIT',
       ['repository.type']: 'git',
-      ['repository.url']: 'git+https://github.com/redwoodjs/redwood.git',
+      ['repository.url']: 'git+https://github.com/redmix-run/redmix.git',
       ['repository.directory']: (workspace) => workspace.cwd,
     })
   },


### PR DESCRIPTION
This is a first pass of replacing redwoodjs/redwood repo links with redmix-run/redmix.
I've kept some redwoodjs/redwood links where they point to specific files at specific hashes (permalinks) or when they point to specific issues or PRs. I want to keep those around for reference as long as they're relevant. 
They're mostly in code comments and docs.

This change is also needed to get CI to run