### PR TITLE
fix(storybook): Adding vite-plugin-node-polyfills to SB Vite config

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -56,7 +56,8 @@
     "@storybook/react": "7.6.20",
     "magic-string": "0.30.11",
     "react-docgen": "7.0.3",
-    "unplugin-auto-import": "0.18.3"
+    "unplugin-auto-import": "0.18.3",
+    "vite-plugin-node-polyfills": "0.23.0"
   },
   "devDependencies": {
     "@types/node": "20.17.10",

--- a/packages/storybook/src/preset.ts
+++ b/packages/storybook/src/preset.ts
@@ -1,7 +1,8 @@
-import { dirname, join } from 'path'
+import path from 'node:path'
 
 import type { PresetProperty } from '@storybook/types'
 import { mergeConfig } from 'vite'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -12,7 +13,7 @@ import { reactDocgen } from './plugins/react-docgen'
 import type { StorybookConfig } from './types'
 
 const getAbsolutePath = (input: string) =>
-  dirname(require.resolve(join(input, 'package.json')))
+  path.dirname(require.resolve(path.join(input, 'package.json')))
 
 export const core: PresetProperty<'core'> = {
   builder: getAbsolutePath('@storybook/builder-vite'),
@@ -32,6 +33,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config) => {
 
   // Needs to run before the react plugin, so add to the front
   plugins.unshift(reactDocgen())
+  plugins.unshift(nodePolyfills())
 
   return mergeConfig(config, {
     // This is necessary as it otherwise just points to the `web` directory,

--- a/yarn.lock
+++ b/yarn.lock
@@ -27790,6 +27790,7 @@ __metadata:
     typescript: "npm:5.6.2"
     unplugin-auto-import: "npm:0.18.3"
     vite: "npm:5.4.16"
+    vite-plugin-node-polyfills: "npm:0.23.0"
   peerDependencies:
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/router": "workspace:*"


### PR DESCRIPTION
Fixing this error

```
Error: ver] ✘ [ERROR] Cannot find module 'vite-plugin-node-polyfills/shims/buffer' from '.' [plugin node-stdlib-browser-alias]
[WebServer] 
[WebServer]     /home/runner/work/redmix/test-project/node_modules/resolve/lib/async.js:146:34:
[WebServer]       146 │                 var moduleError = new Error("Cannot find module '...
[WebServer]           ╵                                   ^
[WebServer] 
[WebServer]     at /home/runner/work/redmix/test-project/node_modules/resolve/lib/async.js:146:35
[WebServer]     at processDirs (/home/runner/work/redmix/test-project/node_modules/resolve/lib/async.js:299:39)
[WebServer]     at isdir (/home/runner/work/redmix/test-project/node_modules/resolve/lib/async.js:306:32)
[WebServer]     at /home/runner/work/redmix/test-project/node_modules/resolve/lib/async.js:34:69
[WebServer]     at FSReqCallback.oncomplete (node:fs:198:21)
[WebServer] 
[WebServer] 3:56:07 PM [vite] Internal server error: Failed to resolve import "vite-plugin-node-polyfills/shims/buffer" from "src/entry.client.tsx". Does the file exist?
[WebServer]   Plugin: vite:import-analysis
[WebServer]   File: /home/runner/work/redmix/test-project/web/src/entry.client.tsx:1:32
[WebServer]   1  |  import __buffer_polyfill from 'vite-plugin-node-polyfills/shims/buffer'
[WebServer]      |                                 ^
[WebServer]   2  |  globalThis.Buffer = globalThis.Buffer || __buffer_polyfill
[WebServer]   3  |  import __global_polyfill from 'vite-plugin-node-polyfills/shims/global'
[WebServer]       at TransformPluginContext._formatError (file:///home/runner/work/redmix/test-project/node_modules/vite/dist/node/chunks/dep-Dyl6b77n.js:49258:41)
[WebServer]       at TransformPluginContext.error (file:///home/runner/work/redmix/test-project/node_modules/vite/dist/node/chunks/dep-Dyl6b77n.js:49253:16)
[WebServer]       at normalizeUrl (file:///home/runner/work/redmix/test-project/node_modules/vite/dist/node/chunks/dep-Dyl6b77n.js:64229:23)
[WebServer]       at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[WebServer]       at async file:///home/runner/work/redmix/test-project/node_modules/vite/dist/node/chunks/dep-Dyl6b77n.js:64361:39
```

```
[WebServer] Error: Context failed with 1 error:
[WebServer] /home/runner/work/redmix/test-project/node_modules/resolve/lib/async.js:146:34: ERROR: [plugin: node-stdlib-browser-alias] Cannot find module 'vite-plugin-node-polyfills/shims/buffer' from '.'
[WebServer]     at failureErrorWithLog (/home/runner/work/redmix/test-project/node_modules/vite/node_modules/esbuild/lib/main.js:1472:15)
[WebServer]     at /home/runner/work/redmix/test-project/node_modules/vite/node_modules/esbuild/lib/main.js:860:16
[WebServer]     at responseCallbacks.<computed> (/home/runner/work/redmix/test-project/node_modules/vite/node_modules/esbuild/lib/main.js:622:9)
[WebServer]     at handleIncomingPacket (/home/runner/work/redmix/test-project/node_modules/vite/node_modules/esbuild/lib/main.js:677:12)
[WebServer]     at Socket.readFromStdout (/home/runner/work/redmix/test-project/node_modules/vite/node_modules/esbuild/lib/main.js:600:7)
[WebServer]     at Socket.emit (node:events:524:28)
[WebServer]     at addChunk (node:internal/streams/readable:561:12)
[WebServer]     at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
[WebServer]     at Readable.push (node:internal/streams/readable:392:5)
[WebServer]     at Pipe.onStreamRead (node:internal/stream_base_commons:191:23) {
[WebServer]   errors: [Getter/Setter],
[WebServer]   warnings: [Getter/Setter]
[WebServer] }
[WebServer] 
[WebServer] Node.js v20.19.0
```

Our vite package already depends on vite-plugin-node-polyfills, but yarn would sometimes place that package inside node_modules inside the vite package instead of at the root node_modules. So when it was requested by Storybook's vite node wouldn't find it. Explicitly adding it to Storybook and its vite config solves this. 