### PR TITLE
chore(cli): async await test that expects rejected promise

### DIFF
--- a/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
@@ -688,7 +688,7 @@ describe('deployTasks', () => {
     expect(tasks[0].skip()).toBeTruthy()
   })
 
-  it('throws an error if there is not enough available space on the server and freeSpaceRequired is not configured', () => {
+  it('throws an error if there is not enough available space on the server and freeSpaceRequired is not configured', async () => {
     const ssh = {
       exec: () => ({ stdout: 'df:1875893' }),
     }
@@ -702,12 +702,12 @@ describe('deployTasks', () => {
       {}, // lifecycle
     )
 
-    expect(() => tasks[0].task({}, {})).rejects.toThrowError(
+    await expect(() => tasks[0].task({}, {})).rejects.toThrowError(
       /Not enough disk space\. You need at least 2048MB free space to continue\. \(Currently 1832MB available\)/,
     )
   })
 
-  it('throws an error if there is less available space on the server than freeSpaceRequired', () => {
+  it('throws an error if there is less available space on the server than freeSpaceRequired', async () => {
     const ssh = {
       exec: () => ({ stdout: 'df:3875893' }),
     }
@@ -723,7 +723,7 @@ describe('deployTasks', () => {
       {}, // lifecycle
     )
 
-    expect(() => tasks[0].task({}, {})).rejects.toThrowError(
+    await expect(() => tasks[0].task({}, {})).rejects.toThrowError(
       /Not enough disk space\. You need at least 4096MB free space to continue/,
     )
   })


### PR DESCRIPTION
Fixing this warning in CI

```
stderr | src/commands/deploy/__tests__/baremetal.test.js > deployTasks > throws an error if there is not enough available space on the server and freeSpaceRequired is not configured
Promise returned by `expect(actual).rejects.toThrowError(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at /home/runner/work/graphql/graphql/packages/cli/src/commands/deploy/__tests__/baremetal.test.js:705:40
```