### PR TITLE
chore(deps): Bump memfs to 4.17.0

### DIFF
--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -46,7 +46,7 @@
     "@redwoodjs/framework-tools": "workspace:*",
     "@types/yargs": "17.0.33",
     "concurrently": "8.2.2",
-    "memfs": "4.15.1",
+    "memfs": "4.17.0",
     "publint": "0.2.12",
     "tsx": "4.19.2",
     "typescript": "5.6.2",

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -40,7 +40,7 @@
     "@redwoodjs/framework-tools": "workspace:*",
     "@types/fs-extra": "11.0.4",
     "@types/yargs": "17.0.33",
-    "memfs": "4.15.1",
+    "memfs": "4.17.0",
     "tsx": "4.19.2",
     "typescript": "5.6.2",
     "vitest": "2.1.9"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,7 @@
     "@babel/cli": "7.26.4",
     "@babel/core": "^7.26.10",
     "@types/archiver": "^6",
-    "memfs": "4.15.1",
+    "memfs": "4.17.0",
     "tsx": "4.19.2",
     "typescript": "5.6.2",
     "vitest": "2.1.9"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -102,7 +102,7 @@
     "@types/yargs-parser": "21.0.3",
     "concurrently": "8.2.2",
     "glob": "11.0.0",
-    "memfs": "4.15.1",
+    "memfs": "4.17.0",
     "publint": "0.2.12",
     "rollup": "4.24.0",
     "tsx": "4.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7889,7 +7889,7 @@ __metadata:
     "@redwoodjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.33"
     concurrently: "npm:8.2.2"
-    memfs: "npm:4.15.1"
+    memfs: "npm:4.17.0"
     publint: "npm:0.2.12"
     tsx: "npm:4.19.2"
     typescript: "npm:5.6.2"
@@ -7986,7 +7986,7 @@ __metadata:
     execa: "npm:5.1.1"
     fs-extra: "npm:11.2.0"
     listr2: "npm:7.0.2"
-    memfs: "npm:4.15.1"
+    memfs: "npm:4.17.0"
     terminal-link: "npm:2.1.1"
     tsx: "npm:4.19.2"
     typescript: "npm:5.6.2"
@@ -8101,7 +8101,7 @@ __metadata:
     latest-version: "npm:5.1.0"
     listr2: "npm:7.0.2"
     lodash: "npm:4.17.21"
-    memfs: "npm:4.15.1"
+    memfs: "npm:4.17.0"
     pascalcase: "npm:1.0.0"
     pluralize: "npm:8.0.0"
     portfinder: "npm:1.0.32"
@@ -8892,7 +8892,7 @@ __metadata:
     glob: "npm:11.0.0"
     http-proxy-middleware: "npm:3.0.3"
     isbot: "npm:5.1.21"
-    memfs: "npm:4.15.1"
+    memfs: "npm:4.17.0"
     publint: "npm:0.2.12"
     react: "npm:19.0.0-rc-f2df5694-20240916"
     react-server-dom-webpack: "npm:19.0.0-rc-f2df5694-20240916"
@@ -22455,15 +22455,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memfs@npm:4.15.1":
-  version: 4.15.1
-  resolution: "memfs@npm:4.15.1"
+"memfs@npm:4.17.0":
+  version: 4.17.0
+  resolution: "memfs@npm:4.17.0"
   dependencies:
     "@jsonjoy.com/json-pack": "npm:^1.0.3"
     "@jsonjoy.com/util": "npm:^1.3.0"
     tree-dump: "npm:^1.0.1"
     tslib: "npm:^2.0.0"
-  checksum: 10c0/9afcf2c491374ffcd12f57aaf4773d40b0372806824eed260280db2404987d949ce81887ec2ae1346b8e11b613f6553ceef57ef2f5eaf91f0762670ec43ee0de
+  checksum: 10c0/2901f69e80e1fbefa8aafe994a253fff6f34eb176d8b80d57476311611e516a11ab4dd93f852c8739fe04f2b57d6a4ca7a1828fa0bd401ce631bcac214b3d58b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
From their changelog: 

* allow setting rdev on node (https://github.com/streamich/memfs/issues/1085) ([2717334](https://github.com/streamich/memfs/commit/2717334372ee92b1892ef12cdc341d43312455f2))
* support UInt8Array in place of Buffer (https://github.com/streamich/memfs/issues/1083) ([0d3662a](https://github.com/streamich/memfs/commit/0d3662a75f09fee7bfc6b73f26c34e0e2922bf6f))