### PR TITLE
chore(deps): Bump prettier to 3.5.3

### DIFF
--- a/.changesets/8.md
+++ b/.changesets/8.md
@@ -1,0 +1,8 @@
+- chore(deps): Bump prettier to 3.5.3 (#8) by @Tobbe
+
+See https://github.com/prettier/prettier/blob/main/CHANGELOG.md for changes.
+
+This change affected us: https://prettier.io/blog/2025/02/09/3.5.0.html#css
+
+Note: Prettier regards this as a minor change. But it did break our tests and
+required code changes on our side. It might do the same for your project!

--- a/docs/docs/tutorial/chapter1/first-page.md
+++ b/docs/docs/tutorial/chapter1/first-page.md
@@ -107,8 +107,9 @@ Previous versions of this tutorial had you build everything without any styling,
 
 ```css title="web/src/index.css"
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
-    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 ul {
   list-style-type: none;

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "npm-packlist": "8.0.2",
     "nx": "20.3.2",
     "ora": "8.2.0",
-    "prettier": "3.4.2",
+    "prettier": "3.5.3",
     "prettier-plugin-curly": "0.3.1",
     "prettier-plugin-packagejson": "2.5.6",
     "prettier-plugin-sh": "0.14.0",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -65,7 +65,7 @@
     "listr2": "7.0.2",
     "lodash": "4.17.21",
     "pascalcase": "1.0.0",
-    "prettier": "3.4.2",
+    "prettier": "3.5.3",
     "prompts": "2.4.2",
     "semver": "7.6.3",
     "smol-toml": "1.3.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,7 +70,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "portfinder": "1.0.32",
-    "prettier": "3.4.2",
+    "prettier": "3.5.3",
     "prisma": "5.20.0",
     "prompts": "2.4.2",
     "rimraf": "6.0.1",

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
@@ -1232,9 +1232,10 @@ exports[`in javascript (default) mode > creates a stylesheet 1`] = `
 .rw-scaffold,
 .rw-toast {
   background-color: #fff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }
 .rw-header {
   display: flex;
@@ -2953,9 +2954,10 @@ exports[`in typescript mode > creates a stylesheet 1`] = `
 .rw-scaffold,
 .rw-toast {
   background-color: #fff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }
 .rw-header {
   display: flex;
@@ -3889,9 +3891,10 @@ exports[`tailwind flag > set to \`false\` generates a scaffold.css with raw CSS 
 .rw-scaffold,
 .rw-toast {
   background-color: #fff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }
 .rw-header {
   display: flex;

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
@@ -599,9 +599,10 @@ exports[`in javascript (default) mode > creates a stylesheet 1`] = `
 .rw-scaffold,
 .rw-toast {
   background-color: #fff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }
 .rw-header {
   display: flex;
@@ -1854,9 +1855,10 @@ exports[`in typescript mode > creates a stylesheet 1`] = `
 .rw-scaffold,
 .rw-toast {
   background-color: #fff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }
 .rw-header {
   display: flex;

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -43,7 +43,7 @@
     "graphql": "16.9.0",
     "jscodeshift": "17.0.0",
     "pascalcase": "1.0.0",
-    "prettier": "3.4.2",
+    "prettier": "3.5.3",
     "tasuku": "2.0.1",
     "typescript": "5.6.2",
     "yargs": "17.7.2"

--- a/packages/create-redwood-rsc-app/package.json
+++ b/packages/create-redwood-rsc-app/package.json
@@ -59,7 +59,7 @@
     "fs-extra": "11.2.0",
     "jsonc-eslint-parser": "^2.4.0",
     "knip": "^5.26.0",
-    "prettier": "^3.3.3",
+    "prettier": "3.5.3",
     "prettier-plugin-curly": "^0.3.0",
     "prettier-plugin-packagejson": "^2.5.1",
     "prettier-plugin-sh": "^0.14.0",

--- a/packages/create-redwood-rsc-app/src/installationDir.ts
+++ b/packages/create-redwood-rsc-app/src/installationDir.ts
@@ -72,7 +72,7 @@ async function promptForInstallationDir() {
     console.log('The `~username` syntax is not supported here')
     console.log(
       'Please use the full path or specify the target directory on the ' +
-      'command line.',
+        'command line.',
     )
 
     return await promptForInstallationDir()

--- a/packages/create-redwood-rsc-app/yarn.lock
+++ b/packages/create-redwood-rsc-app/yarn.lock
@@ -1464,7 +1464,7 @@ __metadata:
     jsonc-eslint-parser: "npm:^2.4.0"
     knip: "npm:^5.26.0"
     node-fetch: "npm:3.3.2"
-    prettier: "npm:^3.3.3"
+    prettier: "npm:3.5.3"
     prettier-plugin-curly: "npm:^0.3.0"
     prettier-plugin-packagejson: "npm:^2.5.1"
     prettier-plugin-sh: "npm:^0.14.0"
@@ -3465,12 +3465,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.3.3":
-  version: 3.4.2
-  resolution: "prettier@npm:3.4.2"
+"prettier@npm:3.5.3":
+  version: 3.5.3
+  resolution: "prettier@npm:3.5.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
+  checksum: 10c0/3880cb90b9dc0635819ab52ff571518c35bd7f15a6e80a2054c05dbc8a3aa6e74f135519e91197de63705bcb38388ded7e7230e2178432a1468005406238b877
   languageName: node
   linkType: hard
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-react": "7.36.1",
     "eslint-plugin-react-hooks": "4.6.0",
-    "prettier": "3.4.2"
+    "prettier": "3.5.3"
   },
   "devDependencies": {
     "@babel/cli": "7.26.4",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -105,7 +105,7 @@
     "fs-extra": "11.2.0",
     "graphql": "16.9.0",
     "kill-port": "1.6.1",
-    "prettier": "3.4.2",
+    "prettier": "3.5.3",
     "rimraf": "6.0.1",
     "source-map": "0.7.4",
     "string-env-interpolation": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8026,7 +8026,7 @@ __metadata:
     listr2: "npm:7.0.2"
     lodash: "npm:4.17.21"
     pascalcase: "npm:1.0.0"
-    prettier: "npm:3.4.2"
+    prettier: "npm:3.5.3"
     prompts: "npm:2.4.2"
     semver: "npm:7.6.3"
     smol-toml: "npm:1.3.1"
@@ -8112,7 +8112,7 @@ __metadata:
     pascalcase: "npm:1.0.0"
     pluralize: "npm:8.0.0"
     portfinder: "npm:1.0.32"
-    prettier: "npm:3.4.2"
+    prettier: "npm:3.5.3"
     prisma: "npm:5.20.0"
     prompts: "npm:2.4.2"
     rimraf: "npm:6.0.1"
@@ -8164,7 +8164,7 @@ __metadata:
     graphql: "npm:16.9.0"
     jscodeshift: "npm:17.0.0"
     pascalcase: "npm:1.0.0"
-    prettier: "npm:3.4.2"
+    prettier: "npm:3.5.3"
     publint: "npm:0.3.11"
     tasuku: "npm:2.0.1"
     tempy: "npm:1.0.1"
@@ -8272,7 +8272,7 @@ __metadata:
     eslint-plugin-prettier: "npm:5.2.1"
     eslint-plugin-react: "npm:7.36.1"
     eslint-plugin-react-hooks: "npm:4.6.0"
-    prettier: "npm:3.4.2"
+    prettier: "npm:3.5.3"
     typescript: "npm:5.6.2"
   languageName: unknown
   linkType: soft
@@ -8441,7 +8441,7 @@ __metadata:
     graphql: "npm:16.9.0"
     graphql-tag: "npm:2.12.6"
     kill-port: "npm:1.6.1"
-    prettier: "npm:3.4.2"
+    prettier: "npm:3.5.3"
     publint: "npm:0.3.11"
     rimraf: "npm:6.0.1"
     source-map: "npm:0.7.4"
@@ -25177,12 +25177,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.4.2":
-  version: 3.4.2
-  resolution: "prettier@npm:3.4.2"
+"prettier@npm:3.5.3":
+  version: 3.5.3
+  resolution: "prettier@npm:3.5.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
+  checksum: 10c0/3880cb90b9dc0635819ab52ff571518c35bd7f15a6e80a2054c05dbc8a3aa6e74f135519e91197de63705bcb38388ded7e7230e2178432a1468005406238b877
   languageName: node
   linkType: hard
 
@@ -26862,7 +26862,7 @@ __metadata:
     npm-packlist: "npm:8.0.2"
     nx: "npm:20.3.2"
     ora: "npm:8.2.0"
-    prettier: "npm:3.4.2"
+    prettier: "npm:3.5.3"
     prettier-plugin-curly: "npm:0.3.1"
     prettier-plugin-packagejson: "npm:2.5.6"
     prettier-plugin-sh: "npm:0.14.0"


### PR DESCRIPTION
See https://github.com/prettier/prettier/blob/main/CHANGELOG.md for changes.

This change affected us: https://prettier.io/blog/2025/02/09/3.5.0.html#css

Note: Prettier regards this as a minor change. But it did break our tests and
required code changes on our side. It might do the same for your project!