### PR TITLE
chore(deps): Bump ioredis to 5.6.0

### DIFF
--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -38,7 +38,7 @@
     "@envelop/testing": "7.0.0",
     "@envelop/types": "5.0.0",
     "@redwoodjs/framework-tools": "workspace:*",
-    "ioredis": "^5.3.2",
+    "ioredis": "5.6.0",
     "nodemon": "3.1.9",
     "tsx": "4.19.2",
     "typescript": "5.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8652,7 +8652,7 @@ __metadata:
     "@n1ru4l/in-memory-live-query-store": "npm:0.10.0"
     "@redwoodjs/framework-tools": "workspace:*"
     graphql: "npm:16.9.0"
-    ioredis: "npm:^5.3.2"
+    ioredis: "npm:5.6.0"
     nodemon: "npm:3.1.9"
     tsx: "npm:4.19.2"
     typescript: "npm:5.6.2"
@@ -19617,9 +19617,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ioredis@npm:^5.3.2":
-  version: 5.4.2
-  resolution: "ioredis@npm:5.4.2"
+"ioredis@npm:5.6.0":
+  version: 5.6.0
+  resolution: "ioredis@npm:5.6.0"
   dependencies:
     "@ioredis/commands": "npm:^1.1.1"
     cluster-key-slot: "npm:^1.1.0"
@@ -19630,7 +19630,7 @@ __metadata:
     redis-errors: "npm:^1.2.0"
     redis-parser: "npm:^3.0.0"
     standard-as-callback: "npm:^2.1.0"
-  checksum: 10c0/e59d2cceb43ed74b487d7b50fa91b93246e734e5d4835c7e62f64e44da072f12ab43b044248012e6f8b76c61a7c091a2388caad50e8ad69a8ce5515a730b23b8
+  checksum: 10c0/a885e5146640fc448706871290ef424ffa39af561f7ee3cf1590085209a509f85e99082bdaaf3cd32fa66758aea3fc2055d1109648ddca96fac4944bf2092c30
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7276a0b4-e552-453e-b2dc-f871dbda7fc7)
