### PR TITLE
chore(lerna): Remove legacy command setting

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,5 @@
 {
   "version": "0.0.1",
   "npmClient": "yarn",
-  "command": {
-    "publish": {
-      "verifyAccess": false
-    }
-  },
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }


### PR DESCRIPTION
Fixes this warning:
```sh
lerna WARN verify-access --verify-access=false and --no-verify-access are no longer needed, because the legacy preemptive access verification is now disabled by default. Requests will fail with appropriate errors when not authorized correctly.
```