### PR TITLE
chore(esm): Make redwood, rw, rwfw and storybook bins ESM compatible

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,7 +33,6 @@
     "redwood": "./dist/bins/redwood.js",
     "rw": "./dist/bins/redwood.js",
     "rwfw": "./dist/bins/rwfw.js",
-    "rx": "./dist/bins/redwood.js",
     "tsc": "./dist/bins/tsc.js"
   },
   "files": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,6 +33,7 @@
     "redwood": "./dist/bins/redwood.js",
     "rw": "./dist/bins/redwood.js",
     "rwfw": "./dist/bins/rwfw.js",
+    "rx": "./dist/bins/redwood.js",
     "tsc": "./dist/bins/tsc.js"
   },
   "files": [

--- a/packages/api/src/bins/redwood.ts
+++ b/packages/api/src/bins/redwood.ts
@@ -1,11 +1,22 @@
 #!/usr/bin/env node
-import { createRequire } from 'module'
 
-const requireFromCli = createRequire(
+/**
+ * This file lets users run the Redmix CLI commands inside the /api directory
+ * in their projects.
+ * This works because of the "bin" field in the @redmix/api package.json file
+ * that points to this file.
+ */
+
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const cliPackageJsonFileUrl = pathToFileURL(
   require.resolve('@redmix/cli/package.json'),
 )
 
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
 const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['redwood'], cliPackageJsonFileUrl)
 
 // If this is defined, we're running through yarn and need to change the cwd.
 // See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
@@ -13,4 +24,4 @@ if (process.env.PROJECT_CWD) {
   process.chdir(process.env.PROJECT_CWD)
 }
 
-requireFromCli(bins['redwood'])
+import(cliEntryPointUrl.toString())

--- a/packages/api/src/bins/rwfw.ts
+++ b/packages/api/src/bins/rwfw.ts
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
-import { createRequire } from 'module'
 
-const requireFromCli = createRequire(
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const cliPackageJsonFileUrl = pathToFileURL(
   require.resolve('@redmix/cli/package.json'),
 )
 
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
 const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['rwfw'], cliPackageJsonFileUrl)
 
 // If this is defined, we're running through yarn and need to change the cwd.
 // See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
@@ -13,4 +17,4 @@ if (process.env.PROJECT_CWD) {
   process.chdir(process.env.PROJECT_CWD)
 }
 
-requireFromCli(bins['rwfw'])
+import(cliEntryPointUrl.toString())

--- a/packages/core/src/bins/redwood.ts
+++ b/packages/core/src/bins/redwood.ts
@@ -1,34 +1,48 @@
 #!/usr/bin/env node
-/**
- * A proxy for running the "redwood" @redmix/cli bin (`yarn redwood`, or `yarn rw`) from @redmix/core.
- *
- * createRequire is for ES modules. require literally doesn't exist in ES modules,
- * so if you want to use it, you have to create it.
- *
- * But that's not why we're using it here. We're using it here to require files from other packages for yarn 3 reasons:
- *
- * > If your package is something that automatically loads plugins (for example eslint),
- * > peer dependencies obviously aren't an option as you can't reasonably list all plugins.
- * > Instead, you should use the createRequire function to load plugins on behalf of the configuration file
- * > that lists the plugins to load, be it the package.json or a custom one like the .eslintrc.js file.
- *
- * See...
- *
- * - https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies
- * - https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules
- */
-import { createRequire } from 'node:module'
 
-// You can think about the argument we're passing to `createRequire` as being kinda like setting the `cwd`:
+// A proxy for running the "redwood" @redmix/cli bin (`yarn redwood`, or
+// `yarn rw`) from @redmix/core.
 //
-// > It's using the path/URL to resolve relative paths (e.g.: createRequire('/foo/bar')('./baz') may load /foo/baz/index.js)
+// createRequire is for ES modules. require literally doesn't exist in ES
+// modules, so if you want to use it, you have to create it.
+//
+// But that's not why we're using it here. We're using it here to require files
+// from other packages for yarn 3 reasons:
+//
+// > If your package is something that automatically loads plugins (for example
+// > eslint), peer dependencies obviously aren't an option as you can't
+// > reasonably list all plugins. Instead, you should use the createRequire
+// > function to load plugins on behalf of the configuration file that lists the
+// > plugins to load, be it the package.json or a custom one like the
+// > .eslintrc.js file.
+//
+// See:
+// - https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies
+// - https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules
+
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+// You can think about the argument we're passing to `createRequire` as being
+// kinda like setting the `cwd`:
+//
+// > It's using the path/URL to resolve relative paths (e.g.:
+// > createRequire('/foo/bar')('./baz') may load /foo/bar/baz/index.js)
+//
+// Example import.meta.url value:
+// file:///Users/tobbe/tmp/rx-create-app/node_modules/@redmix/core/dist/bins/redwood.js
 //
 // See https://github.com/nodejs/node/issues/40567#issuecomment-949825461.
 const require = createRequire(import.meta.url)
-const requireFromCli = createRequire(
+
+// Example value:
+// file:///Users/tobbe/tmp/rx-create-app/node_modules/@redmix/cli/package.json
+const cliPackageJsonFileUrl = pathToFileURL(
   require.resolve('@redmix/cli/package.json'),
 )
 
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
 const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['redwood'], cliPackageJsonFileUrl)
 
-requireFromCli(bins['redwood'])
+import(cliEntryPointUrl.toString())

--- a/packages/core/src/bins/rw-api-server-watch.ts
+++ b/packages/core/src/bins/rw-api-server-watch.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
+
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 
 const require = createRequire(import.meta.url)
-const requireFromApiServer = createRequire(
-  require.resolve('@redmix/api-server/package.json'),
+const pkgJsonPath = require.resolve('@redmix/api-server/package.json')
+const apiServerPackageJsonFileUrl = pathToFileURL(pkgJsonPath)
+const requireFromApiServer = createRequire(apiServerPackageJsonFileUrl)
+const bins = requireFromApiServer('./package.json')['bin']
+const apiServerEntryPointUrl = new URL(
+  bins['rw-api-server-watch'],
+  apiServerPackageJsonFileUrl,
 )
 
-const bins = requireFromApiServer('./package.json')['bin']
-
-requireFromApiServer(bins['rw-api-server-watch'])
+import(apiServerEntryPointUrl.toString())

--- a/packages/core/src/bins/rw-dev-fe.ts
+++ b/packages/core/src/bins/rw-dev-fe.ts
@@ -2,10 +2,10 @@
 import { createRequire } from 'node:module'
 
 const require = createRequire(import.meta.url)
-const requireFromRwVite = createRequire(
-  require.resolve('@redmix/vite/package.json'),
-)
+const pkgPath = require.resolve('@redmix/vite/package.json')
+const vitePackageJsonFileUrl = pathToFileURL(pkgPath)
+const requireFromRxVite = createRequire(vitePackageJsonFileUrl)
+const bins = requireFromRxVite('./package.json')['bin']
+const viteEntryPointUrl = new URL(bins['rw-dev-fe'], vitePackageJsonFileUrl)
 
-const bins = requireFromRwVite('./package.json')['bin']
-
-requireFromRwVite(bins['rw-dev-fe'])
+import(viteEntryPointUrl.toString())

--- a/packages/core/src/bins/rwfw.ts
+++ b/packages/core/src/bins/rwfw.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
+
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 
 const require = createRequire(import.meta.url)
-const requireFromCli = createRequire(
-  require.resolve('@redmix/cli/package.json'),
-)
-
+const pkgJsonPath = require.resolve('@redmix/cli/package.json')
+const cliPackageJsonFileUrl = pathToFileURL(pkgJsonPath)
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
 const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['rwfw'], cliPackageJsonFileUrl)
 
-requireFromCli(bins['rwfw'])
+import(cliEntryPointUrl.toString())

--- a/packages/web/src/bins/redwood.ts
+++ b/packages/web/src/bins/redwood.ts
@@ -1,11 +1,22 @@
 #!/usr/bin/env node
-import { createRequire } from 'module'
 
-const requireFromCli = createRequire(
+/**
+ * This file lets users run the Redmix CLI commands inside the /web directory
+ * in their projects.
+ * This works because of the "bin" field in the @redmix/web package.json file
+ * that points to this file.
+ */
+
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const cliPackageJsonFileUrl = pathToFileURL(
   require.resolve('@redmix/cli/package.json'),
 )
 
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
 const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['redwood'], cliPackageJsonFileUrl)
 
 // If this is defined, we're running through yarn and need to change the cwd.
 // See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
@@ -13,4 +24,4 @@ if (process.env.PROJECT_CWD) {
   process.chdir(process.env.PROJECT_CWD)
 }
 
-requireFromCli(bins['redwood'])
+import(cliEntryPointUrl.toString())

--- a/packages/web/src/bins/rwfw.ts
+++ b/packages/web/src/bins/rwfw.ts
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
-import { createRequire } from 'module'
 
-const requireFromCli = createRequire(
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const cliPackageJsonFileUrl = pathToFileURL(
   require.resolve('@redmix/cli/package.json'),
 )
 
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
 const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['rwfw'], cliPackageJsonFileUrl)
 
 // If this is defined, we're running through yarn and need to change the cwd.
 // See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
@@ -13,4 +17,4 @@ if (process.env.PROJECT_CWD) {
   process.chdir(process.env.PROJECT_CWD)
 }
 
-requireFromCli(bins['rwfw'])
+import(cliEntryPointUrl.toString())

--- a/packages/web/src/bins/storybook.ts
+++ b/packages/web/src/bins/storybook.ts
@@ -12,7 +12,7 @@ function isErrorWithCode(error: unknown): error is { code: string } {
   )
 }
 
-const pkgJsonPath = require.resolve('@redmix/web/package.json')
+const pkgJsonPath = require.resolve('storybook/package.json')
 const storybookPackageJsonFileUrl = pathToFileURL(pkgJsonPath)
 
 // We do not install storybook by default, so we need to check if it is

--- a/packages/web/src/bins/storybook.ts
+++ b/packages/web/src/bins/storybook.ts
@@ -1,18 +1,30 @@
 #!/usr/bin/env node
-import { createRequire } from 'module'
+
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 
 function isErrorWithCode(error: any): error is { code: string } {
   return error.code !== undefined
 }
 
+const storybookPackageJsonFileUrl = pathToFileURL(
+  require.resolve('storybook-framework-redmix-vite/package.json'),
+)
+
 // We do not install storybook by default, so we need to check if it is
 // installed before we try to run it.
 try {
-  const requireFromStorybook = createRequire(
-    require.resolve('storybook/package.json'),
-  )
+  const requireFromStorybook = createRequire(storybookPackageJsonFileUrl)
   const bins = requireFromStorybook('./package.json')['bin']
-  requireFromStorybook(bins['storybook'])
+  const sbEntryPointUrl = new URL(bins['rwfw'], storybookPackageJsonFileUrl)
+
+  // If this is defined, we're running through yarn and need to change the cwd.
+  // See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
+  if (process.env.PROJECT_CWD) {
+    process.chdir(process.env.PROJECT_CWD)
+  }
+
+  import(sbEntryPointUrl.toString())
 } catch (error) {
   if (isErrorWithCode(error) && error.code === 'MODULE_NOT_FOUND') {
     console.error('Storybook is not currently installed.')

--- a/packages/web/src/bins/storybook.ts
+++ b/packages/web/src/bins/storybook.ts
@@ -3,20 +3,27 @@
 import { createRequire } from 'node:module'
 import { pathToFileURL } from 'node:url'
 
-function isErrorWithCode(error: any): error is { code: string } {
-  return error.code !== undefined
+function isErrorWithCode(error: unknown): error is { code: string } {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof error.code === 'string'
+  )
 }
 
-const storybookPackageJsonFileUrl = pathToFileURL(
-  require.resolve('storybook-framework-redmix-vite/package.json'),
-)
+const pkgJsonPath = require.resolve('@redmix/web/package.json')
+const storybookPackageJsonFileUrl = pathToFileURL(pkgJsonPath)
 
 // We do not install storybook by default, so we need to check if it is
 // installed before we try to run it.
 try {
   const requireFromStorybook = createRequire(storybookPackageJsonFileUrl)
   const bins = requireFromStorybook('./package.json')['bin']
-  const sbEntryPointUrl = new URL(bins['rwfw'], storybookPackageJsonFileUrl)
+  const sbEntryPointUrl = new URL(
+    bins['storybook'],
+    storybookPackageJsonFileUrl,
+  )
 
   // If this is defined, we're running through yarn and need to change the cwd.
   // See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.

--- a/tasks/test-project/tui-tasks.ts
+++ b/tasks/test-project/tui-tasks.ts
@@ -3,7 +3,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { Options as ExecaOptions, ExecaChildProcess } from 'execa'
+import type { Options as ExecaOptions } from 'execa'
 
 import type { TuiTaskList } from './typing.js'
 import {
@@ -62,9 +62,7 @@ async function applyCodemod(codemod: string, target: string) {
 function createBuilder(cmd: string, dir = '') {
   const execaOptions = getExecaOptions(path.join(OUTPUT_PATH, dir))
 
-  return function (
-    positionalArguments?: string | string[],
-  ): ExecaChildProcess<string> {
+  return function (positionalArguments?: string | string[]) {
     const subprocess = exec(
       cmd,
       Array.isArray(positionalArguments)
@@ -86,6 +84,9 @@ export async function webTasks(
   const execaOptions = getExecaOptions(outputPath)
 
   const createPages = async () => {
+    // Passing 'web' here to test executing 'yarn redwood' in the /web directory
+    // to make sure it works as expected. We do the same for the /api directory
+    // further down in this file.
     const createPage = createBuilder('yarn redwood g page', 'web')
 
     const tuiTaskList: TuiTaskList = [

--- a/tasks/test-project/tui-tasks.ts
+++ b/tasks/test-project/tui-tasks.ts
@@ -6,13 +6,11 @@ import path from 'node:path'
 import type { Options as ExecaOptions, ExecaChildProcess } from 'execa'
 
 import type { TuiTaskList } from './typing.js'
-
-const {
-  getExecaOptions: utilGetExecaOptions,
-  // applyCodemod,
+import {
+  getExecaOptions as utilGetExecaOptions,
   updatePkgJsonScripts,
   exec,
-} = require('./util')
+} from './util.js'
 
 function getExecaOptions(cwd: string): ExecaOptions {
   return { ...utilGetExecaOptions(cwd), stdio: 'pipe' }
@@ -61,8 +59,8 @@ async function applyCodemod(codemod: string, target: string) {
 /**
  * @param cmd The command to run
  */
-function createBuilder(cmd: string) {
-  const execaOptions = getExecaOptions(OUTPUT_PATH)
+function createBuilder(cmd: string, dir = '') {
+  const execaOptions = getExecaOptions(path.join(OUTPUT_PATH, dir))
 
   return function (
     positionalArguments?: string | string[],
@@ -88,7 +86,7 @@ export async function webTasks(
   const execaOptions = getExecaOptions(outputPath)
 
   const createPages = async () => {
-    const createPage = createBuilder('yarn redwood g page')
+    const createPage = createBuilder('yarn redwood g page', 'web')
 
     const tuiTaskList: TuiTaskList = [
       {
@@ -815,7 +813,7 @@ export default DoublePage`
     {
       title: 'Add users service',
       task: async () => {
-        const generateSdl = createBuilder('yarn redwood g sdl --no-crud')
+        const generateSdl = createBuilder('yarn redwood g sdl --no-crud', 'api')
 
         await generateSdl('user')
 


### PR DESCRIPTION
Once we make `@redmix/cli` an ESM package we can no longer import it using `require`. By changing the bin files here to use `import` instead we make them compatible with with ESM as well as CJS