### PR TITLE
chore(cli): Remove unused export from baremetal

### DIFF
--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -34,13 +34,6 @@ export const description = 'Deploy to baremetal server(s)'
 // systems from a Windows system
 const pathJoin = path.posix.join
 
-export const execaOptions = {
-  cwd: pathJoin(getPaths().base),
-  stdio: 'inherit',
-  shell: true,
-  cleanup: true,
-}
-
 export const builder = (yargs) => {
   yargs.positional('environment', {
     describe: 'The environment to deploy to',


### PR DESCRIPTION
Silly breaking change. I'm pretty sure no one uses the export, but it is possible, so this is a breaking change 🙁 