### PR TITLE
chore(cli): commands/generate/cell: Separate async handler

### DIFF
--- a/packages/cli/src/commands/destroy/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/destroy/cell/__tests__/cell.test.js
@@ -1,6 +1,16 @@
 globalThis.__dirname = __dirname
 
-vi.mock('fs-extra')
+import { vol, fs as memfs } from 'memfs'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
+
+import '../../../../lib/test'
+
+import { files } from '../../../generate/cell/cellHandler.js'
+import { tasks } from '../cell.js'
+
+vi.mock('node:fs', async () => ({ ...memfs, default: memfs }))
+vi.mock('fs-extra', async () => ({ ...memfs, default: memfs }))
+
 vi.mock('../../../../lib', async (importOriginal) => {
   const originalLib = await importOriginal()
   return {
@@ -17,15 +27,6 @@ vi.mock('@redmix/structure', () => {
   }
 })
 
-import fs from 'fs-extra'
-import { vol } from 'memfs'
-import { vi, beforeEach, afterEach, test, expect } from 'vitest'
-
-import '../../../../lib/test'
-
-import { files } from '../../../generate/cell/cell.js'
-import { tasks } from '../cell.js'
-
 beforeEach(() => {
   vi.spyOn(console, 'info').mockImplementation(() => {})
   vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -39,7 +40,9 @@ afterEach(() => {
 
 test('destroys cell files', async () => {
   vol.fromJSON(await files({ name: 'User' }))
-  const unlinkSpy = vi.spyOn(fs, 'unlinkSync')
+
+  const unlinkSpy = vi.spyOn(memfs, 'unlinkSync')
+
   const t = tasks({
     componentName: 'cell',
     filesFn: files,
@@ -56,7 +59,7 @@ test('destroys cell files', async () => {
 
 test('destroys cell files with stories and tests', async () => {
   vol.fromJSON(await files({ name: 'User', stories: true, tests: true }))
-  const unlinkSpy = vi.spyOn(fs, 'unlinkSync')
+  const unlinkSpy = vi.spyOn(memfs, 'unlinkSync')
   const t = tasks({
     componentName: 'cell',
     filesFn: files,

--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
@@ -9,11 +9,9 @@ import { vi, test, describe, beforeEach, afterEach, expect } from 'vitest'
 import '../../../../lib/test'
 
 import { getPaths, getDefaultArgs } from '../../../../lib/index.js'
-import {
-  yargsDefaults as defaults,
-  customOrDefaultTemplatePath,
-} from '../../../generate/helpers.js'
 import { files } from '../../../generate/scaffold/scaffold.js'
+import { yargsDefaults as defaults } from '../../../generate/yargsCommandHelpers.js'
+import { customOrDefaultTemplatePath } from '../../../generate/yargsHandlerHelpers.js'
 import { tasks } from '../scaffold.js'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))

--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
@@ -9,11 +9,9 @@ import { vi, test, describe, beforeEach, afterEach, expect } from 'vitest'
 import '../../../../lib/test'
 
 import { getPaths, getDefaultArgs } from '../../../../lib/index.js'
-import {
-  yargsDefaults as defaults,
-  customOrDefaultTemplatePath,
-} from '../../../generate/helpers.js'
 import { files } from '../../../generate/scaffold/scaffold.js'
+import { yargsDefaults as defaults } from '../../../generate/yargsCommandHelpers.js'
+import { customOrDefaultTemplatePath } from '../../../generate/yargsHandlerHelpers.js'
 import { tasks } from '../scaffold.js'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))

--- a/packages/cli/src/commands/generate/__tests__/createYargsForComponentGeneration.test.js
+++ b/packages/cli/src/commands/generate/__tests__/createYargsForComponentGeneration.test.js
@@ -6,10 +6,10 @@ vi.mock('listr2')
 import { Listr } from 'listr2'
 import { vi, test, expect } from 'vitest'
 
-import * as helpers from '../helpers.js'
+import { createYargsForComponentGeneration } from '../yargsHandlerHelpers.js'
 
 test('createYargsForComponentGeneration generates a yargs handler as expected', async () => {
-  const result = helpers.createYargsForComponentGeneration({
+  const result = createYargsForComponentGeneration({
     componentName: 'bazinga',
     filesFn: () => [],
     includeAdditionalTasks: () => {

--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -1,6 +1,6 @@
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
 
-import fs from 'fs-extra'
 import { vi, test, expect, describe, it } from 'vitest'
 
 // Setup test mocks
@@ -9,9 +9,13 @@ import '../../../lib/test'
 
 import * as helpers from '../helpers.js'
 import * as page from '../page/page.js'
+import {
+  customOrDefaultTemplatePath,
+  templateForComponentFile,
+} from '../yargsHandlerHelpers.js'
 
 test('customOrDefaultTemplatePath returns the default path if no custom templates exist', () => {
-  const output = helpers.customOrDefaultTemplatePath({
+  const output = customOrDefaultTemplatePath({
     side: 'web',
     generator: 'page',
     templatePath: 'page.tsx.template',
@@ -28,7 +32,7 @@ test('customOrDefaultTemplatePath returns the app path if a custom template exis
   // pretend the custom template exists
   vi.spyOn(fs, 'existsSync').mockImplementationOnce(() => true)
 
-  const output = helpers.customOrDefaultTemplatePath({
+  const output = customOrDefaultTemplatePath({
     side: 'web',
     generator: 'page',
     templatePath: 'page.tsx.template',
@@ -43,7 +47,7 @@ test('customOrDefaultTemplatePath returns the app path with proper side, generat
   // pretend the custom template exists
   vi.spyOn(fs, 'existsSync').mockImplementationOnce(() => true)
 
-  const output = helpers.customOrDefaultTemplatePath({
+  const output = customOrDefaultTemplatePath({
     side: 'api',
     generator: 'cell',
     templatePath: 'component.tsx.template',
@@ -60,7 +64,7 @@ test('templateForComponentFile creates a proper output path for files', async ()
   const names = ['FooBar', 'fooBar', 'foo-bar', 'foo_bar']
 
   for (const name of names) {
-    const output = await helpers.templateForComponentFile({
+    const output = await templateForComponentFile({
       name: name,
       suffix: 'Page',
       webPathSection: 'pages',
@@ -82,7 +86,7 @@ test('templateForComponentFile creates a proper output path for files with all c
   const names = ['FOO_BAR', 'FOO-BAR', 'FOOBAR']
 
   for (const name of names) {
-    const output = await helpers.templateForComponentFile({
+    const output = await templateForComponentFile({
       name: name,
       suffix: 'Page',
       webPathSection: 'pages',
@@ -104,7 +108,7 @@ test('templateForComponentFile creates a proper output path for files for starti
   const names = ['FOOBar', 'FOO-Bar', 'FOO_Bar']
 
   for (const name of names) {
-    const output = await helpers.templateForComponentFile({
+    const output = await templateForComponentFile({
       name: name,
       suffix: 'Page',
       webPathSection: 'pages',
@@ -126,7 +130,7 @@ test('templateForComponentFile creates a proper output path for files with upper
   const names = ['ABtest', 'aBtest', 'a-Btest', 'a_Btest']
 
   for (const name of names) {
-    const output = await helpers.templateForComponentFile({
+    const output = await templateForComponentFile({
       name: name,
       suffix: 'Page',
       webPathSection: 'pages',
@@ -145,7 +149,7 @@ test('templateForComponentFile creates a proper output path for files with upper
 })
 
 test('templateForComponentFile can create a path in /web', async () => {
-  const output = await helpers.templateForComponentFile({
+  const output = await templateForComponentFile({
     name: 'Home',
     suffix: 'Page',
     webPathSection: 'pages',
@@ -163,7 +167,7 @@ test('templateForComponentFile can create a path in /web', async () => {
 })
 
 test('templateForComponentFile can create a path in /api', async () => {
-  const output = await helpers.templateForComponentFile({
+  const output = await templateForComponentFile({
     name: 'Home',
     suffix: 'Page',
     apiPathSection: 'services',
@@ -181,7 +185,7 @@ test('templateForComponentFile can create a path in /api', async () => {
 })
 
 test('templateForComponentFile can override generated component name', async () => {
-  const output = await helpers.templateForComponentFile({
+  const output = await templateForComponentFile({
     name: 'Home',
     componentName: 'Hobbiton',
     webPathSection: 'pages',
@@ -199,7 +203,7 @@ test('templateForComponentFile can override generated component name', async () 
 })
 
 test('templateForComponentFile can override file extension', async () => {
-  const output = await helpers.templateForComponentFile({
+  const output = await templateForComponentFile({
     name: 'Home',
     suffix: 'Page',
     extension: '.txt',
@@ -218,7 +222,7 @@ test('templateForComponentFile can override file extension', async () => {
 })
 
 test('templateForComponentFile can override output path', async () => {
-  const output = await helpers.templateForComponentFile({
+  const output = await templateForComponentFile({
     name: 'func',
     apiPathSection: 'functions',
     generator: 'function',
@@ -233,7 +237,7 @@ test('templateForComponentFile can override output path', async () => {
 })
 
 test('templateForComponentFile creates a template', async () => {
-  const output = await helpers.templateForComponentFile({
+  const output = await templateForComponentFile({
     name: 'FooBar',
     suffix: 'Page',
     webPathSection: 'pages',

--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
@@ -5,7 +5,7 @@ import { vi, describe, it, expect, test, beforeAll } from 'vitest'
 
 // Load mocks
 import '../../../../lib/test'
-import * as cell from '../cell.js'
+import * as cellHandler from '../cellHandler.js'
 
 vi.mock('@redmix/structure', () => {
   return {
@@ -19,7 +19,7 @@ describe('Single word files', () => {
   let singleWordFiles
 
   beforeAll(async () => {
-    singleWordFiles = await cell.files({
+    singleWordFiles = await cellHandler.files({
       name: 'User',
       tests: true,
       stories: true,
@@ -75,7 +75,7 @@ describe('Single word files', () => {
 // Single Word Scenario: User
 
 test('trims Cell from end of name', async () => {
-  const files = await cell.files({
+  const files = await cellHandler.files({
     name: 'BazingaCell',
     tests: true,
     stories: true,
@@ -98,7 +98,7 @@ describe('Multiword files', () => {
   let multiWordFiles
 
   beforeAll(async () => {
-    multiWordFiles = await cell.files({
+    multiWordFiles = await cellHandler.files({
       name: 'UserProfile',
       tests: true,
       stories: true,
@@ -152,7 +152,7 @@ describe('Snake case words', () => {
   let snakeCaseWordFiles
 
   beforeAll(async () => {
-    snakeCaseWordFiles = await cell.files({
+    snakeCaseWordFiles = await cellHandler.files({
       name: 'user_profile',
       tests: true,
       stories: true,
@@ -205,7 +205,7 @@ describe('Snake case words', () => {
 describe('Kebab case words', () => {
   let kebabCaseWordFiles
   beforeAll(async () => {
-    kebabCaseWordFiles = await cell.files({
+    kebabCaseWordFiles = await cellHandler.files({
       name: 'user-profile',
       tests: true,
       stories: true,
@@ -259,7 +259,7 @@ describe('camelCase words', () => {
   let camelCaseWordFiles
 
   beforeAll(async () => {
-    camelCaseWordFiles = await cell.files({
+    camelCaseWordFiles = await cellHandler.files({
       name: 'userProfile',
       tests: true,
       stories: true,
@@ -310,7 +310,7 @@ describe('camelCase words', () => {
 })
 
 test("doesn't include test file when --tests is set to false", async () => {
-  const withoutTestFiles = await cell.files({
+  const withoutTestFiles = await cellHandler.files({
     name: 'User',
     tests: false,
     stories: true,
@@ -329,7 +329,7 @@ test("doesn't include test file when --tests is set to false", async () => {
 })
 
 test("doesn't include storybook file when --stories is set to false", async () => {
-  const withoutStoryFiles = await cell.files({
+  const withoutStoryFiles = await cellHandler.files({
     name: 'User',
     tests: true,
     stories: false,
@@ -348,7 +348,7 @@ test("doesn't include storybook file when --stories is set to false", async () =
 })
 
 test("doesn't include storybook and test files when --stories and --tests is set to false", async () => {
-  const withoutTestAndStoryFiles = await cell.files({
+  const withoutTestAndStoryFiles = await cellHandler.files({
     name: 'User',
     tests: false,
     stories: false,
@@ -361,7 +361,7 @@ test("doesn't include storybook and test files when --stories and --tests is set
 })
 
 test('generates list cells if list flag passed in', async () => {
-  const listFlagPassedIn = await cell.files({
+  const listFlagPassedIn = await cellHandler.files({
     name: 'Member',
     tests: true,
     stories: true,
@@ -400,7 +400,7 @@ test('generates list cells if list flag passed in', async () => {
 })
 
 test('generates list cells if name is plural', async () => {
-  const listInferredFromName = await cell.files({
+  const listInferredFromName = await cellHandler.files({
     name: 'Members',
     tests: true,
     stories: true,
@@ -435,7 +435,7 @@ test('generates list cells if name is plural', async () => {
 })
 
 test('TypeScript: generates list cells if list flag passed in', async () => {
-  const findDataByIdTypeScript = await cell.files({
+  const findDataByIdTypeScript = await cellHandler.files({
     name: 'Bazinga',
     tests: true,
     stories: true,
@@ -474,7 +474,7 @@ test('TypeScript: generates list cells if list flag passed in', async () => {
 })
 
 test('TypeScript: generates list cells if name is plural', async () => {
-  const listInferredFromNameTypeScript = await cell.files({
+  const listInferredFromNameTypeScript = await cellHandler.files({
     name: 'Members',
     tests: true,
     stories: true,
@@ -510,7 +510,7 @@ test('TypeScript: generates list cells if name is plural', async () => {
 })
 
 test('"equipment" with list flag', async () => {
-  const modelPluralMatchesSingularWithList = await cell.files({
+  const modelPluralMatchesSingularWithList = await cellHandler.files({
     name: 'equipment',
     tests: true,
     stories: true,
@@ -546,7 +546,7 @@ test('"equipment" with list flag', async () => {
 })
 
 test('"equipment" withOUT list flag should find equipment by id', async () => {
-  const modelPluralMatchesSingularWithoutList = await cell.files({
+  const modelPluralMatchesSingularWithoutList = await cellHandler.files({
     name: 'equipment',
     tests: true,
     stories: true,
@@ -582,7 +582,7 @@ test('"equipment" withOUT list flag should find equipment by id', async () => {
 })
 
 test('generates a cell with a string primary id key', async () => {
-  const modelWithStringId = await cell.files({
+  const modelWithStringId = await cellHandler.files({
     name: 'address',
     tests: true,
     stories: true,
@@ -621,7 +621,7 @@ test('generates a cell with a string primary id key', async () => {
 })
 
 test('generates list a cell with a string primary id keys', async () => {
-  const modelWithStringIdList = await cell.files({
+  const modelWithStringIdList = await cellHandler.files({
     name: 'address',
     tests: true,
     stories: true,
@@ -661,7 +661,7 @@ test('generates list a cell with a string primary id keys', async () => {
 
 describe('Custom query names', () => {
   test('Accepts custom query names', async () => {
-    const generatedFiles = await cell.files({
+    const generatedFiles = await cellHandler.files({
       name: 'Clues',
       tests: false,
       stories: false,
@@ -677,7 +677,7 @@ describe('Custom query names', () => {
 
   test('Throws if a duplicated query name is used', async () => {
     await expect(
-      cell.files({
+      cellHandler.files({
         name: 'Clues',
         tests: false,
         stories: false,
@@ -695,7 +695,7 @@ describe('Custom Id Field files', () => {
 
   describe('Single cell', () => {
     beforeAll(async () => {
-      customIdFieldFiles = await cell.files({
+      customIdFieldFiles = await cellHandler.files({
         name: 'CustomIdField',
         tests: true,
         stories: true,
@@ -750,7 +750,7 @@ describe('Custom Id Field files', () => {
 
   describe('List cell', () => {
     beforeAll(async () => {
-      customIdFieldListFiles = await cell.files({
+      customIdFieldListFiles = await cellHandler.files({
         name: 'CustomIdField',
         tests: true,
         stories: true,

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -1,216 +1,32 @@
-import pascalcase from 'pascalcase'
-
-import { generate as generateTypes } from '@redmix/internal/dist/generate/generate'
-
-import { nameVariants, transformTSToJS } from '../../../lib/index.js'
-import { isWordPluralizable } from '../../../lib/pluralHelpers.js'
-import { addFunctionToRollback } from '../../../lib/rollback.js'
-import { isPlural, singularize } from '../../../lib/rwPluralize.js'
-import { getSchema } from '../../../lib/schemaHelpers.js'
-import { yargsDefaults } from '../helpers.js'
 import {
-  templateForComponentFile,
-  createYargsForComponentGeneration,
-  forcePluralizeWord,
-  removeGeneratorName,
-} from '../helpers.js'
+  createCommand,
+  createDescription,
+  createBuilder,
+} from '../yargsCommandHelpers.js'
 
-import {
-  checkProjectForQueryField,
-  getIdName,
-  getIdType,
-  operationNameIsUnique,
-  uniqueOperationName,
-} from './utils/utils.js'
-
-const COMPONENT_SUFFIX = 'Cell'
-const REDWOOD_WEB_PATH_NAME = 'components'
-
-export const files = async ({ name, typescript, ...options }) => {
-  let cellName = removeGeneratorName(name, 'cell')
-  let idName = 'id'
-  let idType,
-    mockIdValues = [42, 43, 44],
-    model = null
-  let templateNameSuffix = ''
-  let typeName = cellName
-  // Create a unique operation name.
-
-  const shouldGenerateList =
-    (isWordPluralizable(cellName) ? isPlural(cellName) : options.list) ||
-    options.list
-
-  // needed for the singular cell GQL query find by id case
-  try {
-    // todo should pull from graphql schema rather than prisma!
-    model = await getSchema(pascalcase(singularize(cellName)))
-    idName = getIdName(model)
-    idType = getIdType(model)
-    typeName = model.name
-    mockIdValues =
-      idType === 'String'
-        ? mockIdValues.map((value) => `'${value}'`)
-        : mockIdValues
-  } catch {
-    // Eat error so that the destroy cell generator doesn't raise an error
-    // when trying to find prisma query engine in test runs.
-
-    // Assume id will be Int, otherwise generated cell will keep throwing
-    idType = 'Int'
-  }
-
-  if (shouldGenerateList) {
-    cellName = forcePluralizeWord(cellName)
-    templateNameSuffix = 'List'
-    // override operationName so that its find_operationName
-  }
-
-  let operationName = options.query
-  if (operationName) {
-    const userSpecifiedOperationNameIsUnique =
-      await operationNameIsUnique(operationName)
-    if (!userSpecifiedOperationNameIsUnique) {
-      throw new Error(`Specified query name: "${operationName}" is not unique!`)
-    }
-  } else {
-    operationName = await uniqueOperationName(cellName, {
-      list: shouldGenerateList,
-    })
-  }
-
-  const extension = typescript ? '.tsx' : '.jsx'
-  const cellFile = await templateForComponentFile({
-    name: cellName,
-    suffix: COMPONENT_SUFFIX,
-    extension,
-    webPathSection: REDWOOD_WEB_PATH_NAME,
-    generator: 'cell',
-    templatePath: `cell${templateNameSuffix}.tsx.template`,
-    templateVars: {
-      operationName,
-      idName,
-      idType,
+export const command = createCommand('cell')
+export const description = createDescription('cell')
+export const builder = createBuilder({
+  componentName: 'cell',
+  optionsObj: {
+    list: {
+      alias: 'l',
+      default: false,
+      description:
+        'Use when you want to generate a cell for a list of the model name.',
+      type: 'boolean',
     },
-  })
-
-  const testFile = await templateForComponentFile({
-    name: cellName,
-    suffix: COMPONENT_SUFFIX,
-    extension: `.test${extension}`,
-    webPathSection: REDWOOD_WEB_PATH_NAME,
-    generator: 'cell',
-    templatePath: 'test.js.template',
-    templateVars: {
-      idName: shouldGenerateList ? undefined : idName,
-      mockIdValues: shouldGenerateList ? undefined : mockIdValues,
+    query: {
+      default: '',
+      description:
+        'Use to enforce a specific query name within the generated cell - must be unique.',
+      type: 'string',
     },
-  })
+  },
+})
 
-  const storiesFile = await templateForComponentFile({
-    name: cellName,
-    suffix: COMPONENT_SUFFIX,
-    extension: `.stories${extension}`,
-    webPathSection: REDWOOD_WEB_PATH_NAME,
-    generator: 'cell',
-    templatePath: 'stories.tsx.template',
-  })
+export async function handler(options) {
+  const { handler: cellHandler } = await import('./cellHandler')
 
-  const mockFile = await templateForComponentFile({
-    name: cellName,
-    suffix: COMPONENT_SUFFIX,
-    extension: typescript ? '.mock.ts' : '.mock.js',
-    webPathSection: REDWOOD_WEB_PATH_NAME,
-    generator: 'cell',
-    templatePath: `mock${templateNameSuffix}.ts.template`,
-    templateVars: {
-      idName,
-      mockIdValues,
-      typeName,
-    },
-  })
-
-  const files = [cellFile]
-
-  if (options.stories) {
-    files.push(storiesFile)
-  }
-
-  if (options.tests) {
-    files.push(testFile)
-  }
-
-  if (options.stories || options.tests) {
-    files.push(mockFile)
-  }
-
-  // Returns
-  // {
-  //    "path/to/fileA": "<<<template>>>",
-  //    "path/to/fileB": "<<<template>>>",
-  // }
-  return files.reduce(async (accP, [outputPath, content]) => {
-    const acc = await accP
-
-    const template = typescript
-      ? content
-      : await transformTSToJS(outputPath, content)
-
-    return {
-      [outputPath]: template,
-      ...acc,
-    }
-  }, Promise.resolve({}))
+  return cellHandler(options)
 }
-
-export const { command, description, builder, handler } =
-  createYargsForComponentGeneration({
-    componentName: 'cell',
-    filesFn: files,
-    optionsObj: {
-      ...yargsDefaults,
-      list: {
-        alias: 'l',
-        default: false,
-        description:
-          'Use when you want to generate a cell for a list of the model name.',
-        type: 'boolean',
-      },
-      query: {
-        default: '',
-        description:
-          'Use to enforce a specific query name within the generated cell - must be unique.',
-        type: 'string',
-      },
-    },
-    includeAdditionalTasks: ({ name: cellName }) => {
-      return [
-        {
-          title: `Generating types ...`,
-          task: async (_ctx, task) => {
-            const queryFieldName = nameVariants(
-              removeGeneratorName(cellName, 'cell'),
-            ).camelName
-            const projectHasSdl =
-              await checkProjectForQueryField(queryFieldName)
-
-            if (projectHasSdl) {
-              const { errors } = await generateTypes()
-
-              for (const { message, error } of errors) {
-                console.error(message)
-                console.log()
-                console.error(error)
-                console.log()
-              }
-
-              addFunctionToRollback(generateTypes, true)
-            } else {
-              task.skip(
-                `Skipping type generation: no SDL defined for "${queryFieldName}". To generate types, run 'yarn rw g sdl ${queryFieldName}'.`,
-              )
-            }
-          },
-        },
-      ]
-    },
-  })

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -26,7 +26,7 @@ export const builder = createBuilder({
 })
 
 export async function handler(options) {
-  const { handler: cellHandler } = await import('./cellHandler')
+  const { handler: cellHandler } = await import('./cellHandler.js')
 
   return cellHandler(options)
 }

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -2,6 +2,7 @@ import {
   createCommand,
   createDescription,
   createBuilder,
+  yargsDefaults,
 } from '../yargsCommandHelpers.js'
 
 export const command = createCommand('cell')
@@ -9,6 +10,7 @@ export const description = createDescription('cell')
 export const builder = createBuilder({
   componentName: 'cell',
   optionsObj: {
+    ...yargsDefaults,
     list: {
       alias: 'l',
       default: false,

--- a/packages/cli/src/commands/generate/cell/cellHandler.js
+++ b/packages/cli/src/commands/generate/cell/cellHandler.js
@@ -1,0 +1,196 @@
+import pascalcase from 'pascalcase'
+
+import { generate as generateTypes } from '@redmix/internal/dist/generate/generate'
+
+import { nameVariants, transformTSToJS } from '../../../lib/index.js'
+import { isWordPluralizable } from '../../../lib/pluralHelpers.js'
+import { addFunctionToRollback } from '../../../lib/rollback.js'
+import { isPlural, singularize } from '../../../lib/rwPluralize.js'
+import { getSchema } from '../../../lib/schemaHelpers.js'
+import { forcePluralizeWord, removeGeneratorName } from '../helpers.js'
+import {
+  createHandler,
+  templateForComponentFile,
+} from '../yargsHandlerHelpers.js'
+
+import {
+  checkProjectForQueryField,
+  getIdName,
+  getIdType,
+  operationNameIsUnique,
+  uniqueOperationName,
+} from './utils/utils.js'
+
+const COMPONENT_SUFFIX = 'Cell'
+const REDWOOD_WEB_PATH_NAME = 'components'
+
+export const files = async ({ name, typescript, ...options }) => {
+  let cellName = removeGeneratorName(name, 'cell')
+  let idName = 'id'
+  let idType,
+    mockIdValues = [42, 43, 44],
+    model = null
+  let templateNameSuffix = ''
+  let typeName = cellName
+  // Create a unique operation name.
+
+  const shouldGenerateList =
+    (isWordPluralizable(cellName) ? isPlural(cellName) : options.list) ||
+    options.list
+
+  // needed for the singular cell GQL query find by id case
+  try {
+    // todo should pull from graphql schema rather than prisma!
+    model = await getSchema(pascalcase(singularize(cellName)))
+    idName = getIdName(model)
+    idType = getIdType(model)
+    typeName = model.name
+    mockIdValues =
+      idType === 'String'
+        ? mockIdValues.map((value) => `'${value}'`)
+        : mockIdValues
+  } catch {
+    // Eat error so that the destroy cell generator doesn't raise an error
+    // when trying to find prisma query engine in test runs.
+
+    // Assume id will be Int, otherwise generated cell will keep throwing
+    idType = 'Int'
+  }
+
+  if (shouldGenerateList) {
+    cellName = forcePluralizeWord(cellName)
+    templateNameSuffix = 'List'
+    // override operationName so that its find_operationName
+  }
+
+  let operationName = options.query
+  if (operationName) {
+    const userSpecifiedOperationNameIsUnique =
+      await operationNameIsUnique(operationName)
+    if (!userSpecifiedOperationNameIsUnique) {
+      throw new Error(`Specified query name: "${operationName}" is not unique!`)
+    }
+  } else {
+    operationName = await uniqueOperationName(cellName, {
+      list: shouldGenerateList,
+    })
+  }
+
+  const extension = typescript ? '.tsx' : '.jsx'
+  const cellFile = await templateForComponentFile({
+    name: cellName,
+    suffix: COMPONENT_SUFFIX,
+    extension,
+    webPathSection: REDWOOD_WEB_PATH_NAME,
+    generator: 'cell',
+    templatePath: `cell${templateNameSuffix}.tsx.template`,
+    templateVars: {
+      operationName,
+      idName,
+      idType,
+    },
+  })
+
+  const testFile = await templateForComponentFile({
+    name: cellName,
+    suffix: COMPONENT_SUFFIX,
+    extension: `.test${extension}`,
+    webPathSection: REDWOOD_WEB_PATH_NAME,
+    generator: 'cell',
+    templatePath: 'test.js.template',
+    templateVars: {
+      idName: shouldGenerateList ? undefined : idName,
+      mockIdValues: shouldGenerateList ? undefined : mockIdValues,
+    },
+  })
+
+  const storiesFile = await templateForComponentFile({
+    name: cellName,
+    suffix: COMPONENT_SUFFIX,
+    extension: `.stories${extension}`,
+    webPathSection: REDWOOD_WEB_PATH_NAME,
+    generator: 'cell',
+    templatePath: 'stories.tsx.template',
+  })
+
+  const mockFile = await templateForComponentFile({
+    name: cellName,
+    suffix: COMPONENT_SUFFIX,
+    extension: typescript ? '.mock.ts' : '.mock.js',
+    webPathSection: REDWOOD_WEB_PATH_NAME,
+    generator: 'cell',
+    templatePath: `mock${templateNameSuffix}.ts.template`,
+    templateVars: {
+      idName,
+      mockIdValues,
+      typeName,
+    },
+  })
+
+  const files = [cellFile]
+
+  if (options.stories) {
+    files.push(storiesFile)
+  }
+
+  if (options.tests) {
+    files.push(testFile)
+  }
+
+  if (options.stories || options.tests) {
+    files.push(mockFile)
+  }
+
+  // Returns
+  // {
+  //    "path/to/fileA": "<<<template>>>",
+  //    "path/to/fileB": "<<<template>>>",
+  // }
+  return files.reduce(async (accP, [outputPath, content]) => {
+    const acc = await accP
+
+    const template = typescript
+      ? content
+      : await transformTSToJS(outputPath, content)
+
+    return {
+      [outputPath]: template,
+      ...acc,
+    }
+  }, Promise.resolve({}))
+}
+
+export const handler = createHandler({
+  componentName: 'cell',
+  filesFn: files,
+  includeAdditionalTasks: ({ name: cellName }) => {
+    return [
+      {
+        title: `Generating types ...`,
+        task: async (_ctx, task) => {
+          const queryFieldName = nameVariants(
+            removeGeneratorName(cellName, 'cell'),
+          ).camelName
+          const projectHasSdl = await checkProjectForQueryField(queryFieldName)
+
+          if (projectHasSdl) {
+            const { errors } = await generateTypes()
+
+            for (const { message, error } of errors) {
+              console.error(message)
+              console.log()
+              console.error(error)
+              console.log()
+            }
+
+            addFunctionToRollback(generateTypes, true)
+          } else {
+            task.skip(
+              `Skipping type generation: no SDL defined for "${queryFieldName}". To generate types, run 'yarn rw g sdl ${queryFieldName}'.`,
+            )
+          }
+        },
+      },
+    ]
+  },
+})

--- a/packages/cli/src/commands/generate/component/component.js
+++ b/packages/cli/src/commands/generate/component/component.js
@@ -1,8 +1,8 @@
 import { transformTSToJS } from '../../../lib/index.js'
 import {
-  templateForComponentFile,
   createYargsForComponentGeneration,
-} from '../helpers.js'
+  templateForComponentFile,
+} from '../yargsHandlerHelpers.js'
 
 const REDWOOD_WEB_PATH_NAME = 'components'
 

--- a/packages/cli/src/commands/generate/dataMigration/dataMigration.js
+++ b/packages/cli/src/commands/generate/dataMigration/dataMigration.js
@@ -10,7 +10,8 @@ import { recordTelemetryAttributes } from '@redmix/cli-helpers'
 import c from '../../../lib/colors.js'
 import { getPaths, writeFilesTask } from '../../../lib/index.js'
 import { prepareForRollback } from '../../../lib/rollback.js'
-import { validateName, yargsDefaults } from '../helpers.js'
+import { validateName } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
 
 const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.warning(
   'After writing your migration, you can run it with:',

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -20,8 +20,8 @@ import {
   writeFilesTask,
 } from '../../../lib/index.js'
 import { prepareForRollback } from '../../../lib/rollback.js'
-import { yargsDefaults } from '../helpers.js'
-import { templateForComponentFile } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { templateForComponentFile } from '../yargsHandlerHelpers.js'
 
 const ROUTES = [
   `<Route path="/login" page={LoginPage} name="login" />`,

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -18,12 +18,12 @@ import {
   prepareForRollback,
   addFunctionToRollback,
 } from '../../../lib/rollback.js'
-import { yargsDefaults } from '../helpers.js'
+import { validateName } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
 import {
   createYargsForComponentGeneration,
   templateForComponentFile,
-  validateName,
-} from '../helpers.js'
+} from '../yargsHandlerHelpers.js'
 
 export const files = async ({ name, typescript = false, type, tests }) => {
   if (tests === undefined) {

--- a/packages/cli/src/commands/generate/function/function.js
+++ b/packages/cli/src/commands/generate/function/function.js
@@ -14,8 +14,9 @@ import {
   writeFilesTask,
 } from '../../../lib/index.js'
 import { prepareForRollback } from '../../../lib/rollback.js'
-import { yargsDefaults } from '../helpers.js'
-import { validateName, templateForComponentFile } from '../helpers.js'
+import { validateName } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { templateForComponentFile } from '../yargsHandlerHelpers.js'
 
 export const files = async ({
   name,

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -1,88 +1,17 @@
-import path from 'path'
+// This file should only be asynchronously imported by the CLI (typically by
+// being statically imported by a *Handler.js file that is in turn
+// asynchronously imported by the CLI.)
+//
+// Importing this file has side effects that can't be run until after we've set
+// CWD, plus importing this file statically also makes the CLI startup time
+// much slower
 
 import { paramCase } from 'change-case'
-import fs from 'fs-extra'
-import { Listr } from 'listr2'
 import pascalcase from 'pascalcase'
-import terminalLink from 'terminal-link'
 
-import {
-  recordTelemetryAttributes,
-  isTypeScriptProject,
-} from '@redmix/cli-helpers'
-import { getConfig, ensurePosixPath } from '@redmix/project-config'
-import { errorTelemetry } from '@redmix/telemetry'
+import { isTypeScriptProject } from '@redmix/cli-helpers'
 
-import c from '../../lib/colors.js'
-import { generateTemplate, getPaths, writeFilesTask } from '../../lib/index.js'
-import { prepareForRollback } from '../../lib/rollback.js'
 import { pluralize, isPlural, isSingular } from '../../lib/rwPluralize.js'
-
-/**
- * Returns the full path to a custom generator template, if found in the app.
- * Otherwise the default Redwood template.
- */
-export const customOrDefaultTemplatePath = ({
-  side,
-  generator,
-  templatePath,
-}) => {
-  // default template for this generator: ./page/templates/page.tsx.template
-  const defaultPath = path.join(__dirname, generator, 'templates', templatePath)
-
-  // where a custom template *might* exist: /path/to/app/web/generators/page/page.tsx.template
-  const customPath = path.join(
-    getPaths()[side].generators,
-    generator,
-    templatePath,
-  )
-
-  if (fs.existsSync(customPath)) {
-    return customPath
-  } else {
-    return defaultPath
-  }
-}
-
-/**
- * Reduces boilerplate for generating an output path and content to write to disk
- * for a component.
- */
-// TODO: Make this read all the files in a template directory instead of
-// manually passing in each file.
-export const templateForComponentFile = async ({
-  name,
-  suffix = '',
-  extension = '.js',
-  webPathSection,
-  apiPathSection,
-  generator,
-  templatePath,
-  templateVars,
-  componentName,
-  outputPath,
-}) => {
-  const basePath = webPathSection
-    ? getPaths().web[webPathSection]
-    : getPaths().api[apiPathSection]
-  const outputComponentName = componentName || pascalcase(name) + suffix
-  const componentOutputPath =
-    outputPath ||
-    path.join(basePath, outputComponentName, outputComponentName + extension)
-  const fullTemplatePath = customOrDefaultTemplatePath({
-    generator,
-    templatePath,
-    side: webPathSection ? 'web' : 'api',
-  })
-  const content = await generateTemplate(fullTemplatePath, {
-    name,
-    outputPath: ensurePosixPath(
-      `./${path.relative(getPaths().base, componentOutputPath)}`,
-    ),
-    ...templateVars,
-  })
-  return [componentOutputPath, content]
-}
 
 /**
  * Creates a route path, either returning the existing path if passed, or
@@ -103,19 +32,6 @@ export const pathName = (path, name) => {
   return routePath
 }
 
-const appendPositionalsToCmd = (commandString, positionalsObj) => {
-  // Add positionals like `page <name>` + ` [path]` if specified
-  if (Object.keys(positionalsObj).length > 0) {
-    const positionalNames = Object.keys(positionalsObj)
-      .map((positionalName) => `[${positionalName}]`)
-      .join(' ')
-    // Note space after command is important
-    return `${commandString} ${positionalNames}`
-  } else {
-    return commandString
-  }
-}
-
 /** @type {(name: string, generatorName: string) => string } **/
 export function removeGeneratorName(name, generatorName) {
   // page -> Page
@@ -127,137 +43,11 @@ export function removeGeneratorName(name, generatorName) {
   return coercedName
 }
 
-/** @type {Record<string, import('yargs').Options>} */
-export const yargsDefaults = {
-  force: {
-    alias: 'f',
-    default: false,
-    description: 'Overwrite existing files',
-    type: 'boolean',
-  },
-  typescript: {
-    alias: 'ts',
-    default: isTypeScriptProject(),
-    description: 'Generate TypeScript files',
-    type: 'boolean',
-  },
-}
-
 export const validateName = (name) => {
   if (name.match(/^\W/)) {
     throw new Error(
       'The <name> argument must start with a letter, number or underscore.',
     )
-  }
-}
-
-/**
- * Reduces boilerplate for creating a yargs handler that writes a
- * component/page/layout/etc to a location.
- */
-export const createYargsForComponentGeneration = ({
-  componentName,
-  preTasksFn = (options) => options,
-  /** filesFn is not used if generator implements its own `handler` */
-  filesFn = () => ({}),
-  optionsObj = yargsDefaults,
-  positionalsObj = {},
-  /** function that takes the options object and returns an array of listr tasks */
-  includeAdditionalTasks = () => [],
-}) => {
-  return {
-    command: appendPositionalsToCmd(`${componentName} <name>`, positionalsObj),
-    description: `Generate a ${componentName} component`,
-    builder: (yargs) => {
-      yargs
-        .positional('name', {
-          description: `Name of the ${componentName}`,
-          type: 'string',
-        })
-        .epilogue(
-          `Also see the ${terminalLink(
-            'Redwood CLI Reference',
-            `https://redwoodjs.com/docs/cli-commands#generate-${componentName}`,
-          )}`,
-        )
-        .option('tests', {
-          description: 'Generate test files',
-          type: 'boolean',
-        })
-        .option('stories', {
-          description: 'Generate storybook files',
-          type: 'boolean',
-        })
-        .option('verbose', {
-          description: 'Print all logs',
-          type: 'boolean',
-          default: false,
-        })
-        .option('rollback', {
-          description: 'Revert all generator actions if an error occurs',
-          type: 'boolean',
-          default: true,
-        })
-
-      // Add in passed in positionals
-      Object.entries(positionalsObj).forEach(([option, config]) => {
-        yargs.positional(option, config)
-      })
-      // Add in passed in options
-      Object.entries(optionsObj).forEach(([option, config]) => {
-        yargs.option(option, config)
-      })
-    },
-    handler: async (options) => {
-      recordTelemetryAttributes({
-        command: `generate ${componentName}`,
-        tests: options.tests,
-        stories: options.stories,
-        verbose: options.verbose,
-        rollback: options.rollback,
-        force: options.force,
-        // TODO: This does not cover the specific options that each generator might pass in
-      })
-
-      if (options.tests === undefined) {
-        options.tests = getConfig().generate.tests
-      }
-      if (options.stories === undefined) {
-        options.stories = getConfig().generate.stories
-      }
-      validateName(options.name)
-
-      try {
-        options = await preTasksFn(options)
-
-        const tasks = new Listr(
-          [
-            {
-              title: `Generating ${componentName} files...`,
-              task: async () => {
-                const f = await filesFn(options)
-                return writeFilesTask(f, { overwriteExisting: options.force })
-              },
-            },
-            ...includeAdditionalTasks(options),
-          ],
-          {
-            rendererOptions: { collapseSubtasks: false },
-            exitOnError: true,
-            renderer: options.verbose && 'verbose',
-          },
-        )
-
-        if (options.rollback && !options.force) {
-          prepareForRollback(tasks)
-        }
-        await tasks.run()
-      } catch (e) {
-        errorTelemetry(process.argv, e.message)
-        console.error(c.error(e.message))
-        process.exit(e?.exitCode || 1)
-      }
-    },
   }
 }
 

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -9,8 +9,6 @@
 import { paramCase } from 'change-case'
 import pascalcase from 'pascalcase'
 
-import { isTypeScriptProject } from '@redmix/cli-helpers'
-
 import { pluralize, isPlural, isSingular } from '../../lib/rwPluralize.js'
 
 /**

--- a/packages/cli/src/commands/generate/job/job.js
+++ b/packages/cli/src/commands/generate/job/job.js
@@ -17,8 +17,9 @@ import {
 } from '../../../lib/index.js'
 import { isTypeScriptProject } from '../../../lib/project.js'
 import { prepareForRollback } from '../../../lib/rollback.js'
-import { yargsDefaults } from '../helpers.js'
-import { validateName, templateForComponentFile } from '../helpers.js'
+import { validateName } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { templateForComponentFile } from '../yargsHandlerHelpers.js'
 
 // Try to make the name end up looking like: `WelcomeNotice` even if the user
 // called it `welcome-notice` or `welcomeNoticeJob` or something like that

--- a/packages/cli/src/commands/generate/layout/layout.js
+++ b/packages/cli/src/commands/generate/layout/layout.js
@@ -1,10 +1,10 @@
 import { transformTSToJS } from '../../../lib/index.js'
-import { yargsDefaults } from '../helpers.js'
+import { removeGeneratorName } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
 import {
   templateForComponentFile,
   createYargsForComponentGeneration,
-  removeGeneratorName,
-} from '../helpers.js'
+} from '../yargsHandlerHelpers.js'
 
 const COMPONENT_SUFFIX = 'Layout'
 const REDWOOD_WEB_PATH_NAME = 'layouts'

--- a/packages/cli/src/commands/generate/model/model.js
+++ b/packages/cli/src/commands/generate/model/model.js
@@ -13,7 +13,8 @@ import {
 } from '../../../lib/index.js'
 import { prepareForRollback } from '../../../lib/rollback.js'
 import { verifyModelName } from '../../../lib/schemaHelpers.js'
-import { validateName, yargsDefaults } from '../helpers.js'
+import { validateName } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'model.js.template')
 
 const files = async ({ name, typescript = false }) => {

--- a/packages/cli/src/commands/generate/ogImage/ogImage.js
+++ b/packages/cli/src/commands/generate/ogImage/ogImage.js
@@ -18,7 +18,7 @@ import {
 } from '../../../lib/index.js'
 import { isTypeScriptProject } from '../../../lib/project.js'
 import { prepareForRollback } from '../../../lib/rollback.js'
-import { customOrDefaultTemplatePath } from '../helpers.js'
+import { customOrDefaultTemplatePath } from '../yargsHandlerHelpers.js'
 
 export const files = async ({ pagePath, typescript = false }) => {
   const extension = typescript ? '.tsx' : '.jsx'

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -20,13 +20,15 @@ import {
   addFunctionToRollback,
 } from '../../../lib/rollback.js'
 import {
-  createYargsForComponentGeneration,
   pathName,
-  templateForComponentFile,
   mapRouteParamTypeToTsType,
   removeGeneratorName,
   validateName,
 } from '../helpers.js'
+import {
+  createYargsForComponentGeneration,
+  templateForComponentFile,
+} from '../yargsHandlerHelpers.js'
 
 const COMPONENT_SUFFIX = 'Page'
 const REDWOOD_WEB_PATH_NAME = 'pages'

--- a/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
@@ -8,7 +8,7 @@ import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 import { getDefaultArgs } from '../../../../lib/index.js'
-import { yargsDefaults as defaults } from '../../helpers.js'
+import { yargsDefaults as defaults } from '../../yargsCommandHelpers.js'
 import * as scaffold from '../scaffold.js'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -9,7 +9,7 @@ import { vi, describe, test, expect, afterAll, beforeAll } from 'vitest'
 import '../../../../lib/test'
 
 import { getDefaultArgs } from '../../../../lib/index.js'
-import { yargsDefaults as defaults } from '../../helpers.js'
+import { yargsDefaults as defaults } from '../../yargsCommandHelpers.js'
 import * as scaffold from '../scaffold.js'
 
 vi.mock('fs-extra', async (importOriginal) => {

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldCustomIdName.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldCustomIdName.test.js
@@ -8,7 +8,7 @@ import { vi, describe, beforeAll, test, expect } from 'vitest'
 import '../../../../lib/test'
 
 import { getDefaultArgs } from '../../../../lib/index.js'
-import { yargsDefaults as defaults } from '../../helpers.js'
+import { yargsDefaults as defaults } from '../../yargsCommandHelpers.js'
 import * as scaffold from '../scaffold.js'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldNoNest.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldNoNest.test.js
@@ -8,7 +8,7 @@ import { vi, describe, beforeAll, test, expect } from 'vitest'
 import '../../../../lib/test'
 
 import { getDefaultArgs } from '../../../../lib/index.js'
-import { yargsDefaults as defaults } from '../../helpers.js'
+import { yargsDefaults as defaults } from '../../yargsCommandHelpers.js'
 import * as scaffold from '../scaffold.js'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))

--- a/packages/cli/src/commands/generate/scaffold/__tests__/shouldUseEmptyAsUndefined.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/shouldUseEmptyAsUndefined.test.js
@@ -8,7 +8,7 @@ import { vi, describe, beforeAll, test, expect } from 'vitest'
 import '../../../../lib/test'
 
 import { getDefaultArgs } from '../../../../lib/index.js'
-import { yargsDefaults as defaults } from '../../helpers.js'
+import { yargsDefaults as defaults } from '../../yargsCommandHelpers.js'
 import * as scaffold from '../scaffold.js'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -32,9 +32,7 @@ import {
 } from '../../../lib/rollback.js'
 import { pluralize, singularize } from '../../../lib/rwPluralize.js'
 import { getSchema, verifyModelName } from '../../../lib/schemaHelpers.js'
-import { yargsDefaults } from '../helpers.js'
 import {
-  customOrDefaultTemplatePath,
   relationsForModel,
   intForeignKeysForModel,
   mapPrismaScalarToPagePropTsType,
@@ -44,6 +42,8 @@ import {
   files as serviceFiles,
   builder as serviceBuilder,
 } from '../service/service.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { customOrDefaultTemplatePath } from '../yargsHandlerHelpers.js'
 
 // Any assets that should not trigger an overwrite error and require a --force
 const SKIPPABLE_ASSETS = ['scaffold.css']

--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -14,7 +14,8 @@ import {
   transformTSToJS,
 } from '../../../lib/index.js'
 import { prepareForRollback } from '../../../lib/rollback.js'
-import { validateName, yargsDefaults } from '../helpers.js'
+import { validateName } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
 
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'script.ts.template')
 const TSCONFIG_TEMPLATE = path.resolve(

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -28,9 +28,10 @@ import {
   getEnum,
   verifyModelName,
 } from '../../../lib/schemaHelpers.js'
-import { yargsDefaults } from '../helpers.js'
-import { customOrDefaultTemplatePath, relationsForModel } from '../helpers.js'
+import { relationsForModel } from '../helpers.js'
 import { files as serviceFiles } from '../service/service.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { customOrDefaultTemplatePath } from '../yargsHandlerHelpers.js'
 
 const DEFAULT_IGNORE_FIELDS_FOR_INPUT = ['createdAt', 'updatedAt']
 

--- a/packages/cli/src/commands/generate/service/service.js
+++ b/packages/cli/src/commands/generate/service/service.js
@@ -4,11 +4,12 @@ import terminalLink from 'terminal-link'
 import { transformTSToJS } from '../../../lib/index.js'
 import { pluralize, singularize } from '../../../lib/rwPluralize.js'
 import { getSchema, verifyModelName } from '../../../lib/schemaHelpers.js'
-import { yargsDefaults, relationsForModel } from '../helpers.js'
+import { relationsForModel } from '../helpers.js'
+import { yargsDefaults } from '../yargsCommandHelpers.js'
 import {
   createYargsForComponentGeneration,
   templateForComponentFile,
-} from '../helpers.js'
+} from '../yargsHandlerHelpers.js'
 
 const DEFAULT_SCENARIO_NAMES = ['one', 'two']
 

--- a/packages/cli/src/commands/generate/yargsCommandHelpers.js
+++ b/packages/cli/src/commands/generate/yargsCommandHelpers.js
@@ -43,7 +43,7 @@ export function createDescription(componentName) {
 
 export function createBuilder({
   componentName,
-  optionsObj = {},
+  optionsObj = yargsDefaults,
   positionalsObj = {},
 }) {
   return (yargs) => {

--- a/packages/cli/src/commands/generate/yargsCommandHelpers.js
+++ b/packages/cli/src/commands/generate/yargsCommandHelpers.js
@@ -1,0 +1,90 @@
+// This file is safe to statically import in the CLI
+import terminalLink from 'terminal-link'
+
+// Don't import anything here that isn't already imported by the CLI
+import { isTypeScriptProject } from '@redmix/cli-helpers'
+
+/** @type {Record<string, import('yargs').Options>} */
+export const yargsDefaults = {
+  force: {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing files',
+    type: 'boolean',
+  },
+  typescript: {
+    alias: 'ts',
+    default: isTypeScriptProject(),
+    description: 'Generate TypeScript files',
+    type: 'boolean',
+  },
+}
+
+const appendPositionalsToCmd = (commandString, positionalsObj) => {
+  // Add positionals like `page <name>` + ` [path]` if specified
+  if (Object.keys(positionalsObj).length > 0) {
+    const positionalNames = Object.keys(positionalsObj)
+      .map((positionalName) => `[${positionalName}]`)
+      .join(' ')
+    // Note space after command is important
+    return `${commandString} ${positionalNames}`
+  } else {
+    return commandString
+  }
+}
+
+export function createCommand(componentName, positionalsObj = {}) {
+  return appendPositionalsToCmd(`${componentName} <name>`, positionalsObj)
+}
+
+export function createDescription(componentName) {
+  return `Generate a ${componentName} component`
+}
+
+export function createBuilder({
+  componentName,
+  optionsObj = {},
+  positionalsObj = {},
+}) {
+  return (yargs) => {
+    yargs
+      .positional('name', {
+        description: `Name of the ${componentName}`,
+        type: 'string',
+      })
+      .epilogue(
+        `Also see the ${terminalLink(
+          'Redwood CLI Reference',
+          `https://redwoodjs.com/docs/cli-commands#generate-${componentName}`,
+        )}`,
+      )
+      .option('tests', {
+        description: 'Generate test files',
+        type: 'boolean',
+      })
+      .option('stories', {
+        description: 'Generate storybook files',
+        type: 'boolean',
+      })
+      .option('verbose', {
+        description: 'Print all logs',
+        type: 'boolean',
+        default: false,
+      })
+      .option('rollback', {
+        description: 'Revert all generator actions if an error occurs',
+        type: 'boolean',
+        default: true,
+      })
+
+    // Add in passed in positionals
+    Object.entries(positionalsObj).forEach(([option, config]) => {
+      yargs.positional(option, config)
+    })
+
+    // Add in passed in options
+    Object.entries(optionsObj).forEach(([option, config]) => {
+      yargs.option(option, config)
+    })
+  }
+}

--- a/packages/cli/src/commands/generate/yargsHandlerHelpers.js
+++ b/packages/cli/src/commands/generate/yargsHandlerHelpers.js
@@ -105,7 +105,7 @@ export const validateName = (name) => {
 
 export function createHandler({
   componentName,
-  preTasksFn,
+  preTasksFn = (options) => options,
   filesFn,
   includeAdditionalTasks,
 }) {

--- a/packages/cli/src/commands/generate/yargsHandlerHelpers.js
+++ b/packages/cli/src/commands/generate/yargsHandlerHelpers.js
@@ -1,0 +1,191 @@
+// This file should only be asynchronously imported by the CLI (typically by
+// being statically imported by a *Handler.js file that is in turn
+// asynchronously imported by the CLI.)
+//
+// Importing this file has side effects that can't be run until after we've set
+// CWD, plus importing this file statically also makes the CLI startup time
+// much slower
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { Listr } from 'listr2'
+import pascalcase from 'pascalcase'
+
+import { recordTelemetryAttributes } from '@redmix/cli-helpers'
+import { ensurePosixPath, getConfig } from '@redmix/project-config'
+import { errorTelemetry } from '@redmix/telemetry'
+
+import c from '../../lib/colors.js'
+import { generateTemplate, getPaths, writeFilesTask } from '../../lib/index.js'
+import { prepareForRollback } from '../../lib/rollback.js'
+
+// TODO: Remove this import. This is only temporarily to be able to split one
+// command at a time into a separate async handler
+import {
+  createCommand,
+  createDescription,
+  createBuilder,
+  yargsDefaults,
+} from './yargsCommandHelpers.js'
+
+/**
+ * Returns the full path to a custom generator template, if found in the app.
+ * Otherwise the default Redwood template.
+ */
+export const customOrDefaultTemplatePath = ({
+  side,
+  generator,
+  templatePath,
+}) => {
+  // default template for this generator: ./page/templates/page.tsx.template
+  const defaultPath = path.join(__dirname, generator, 'templates', templatePath)
+
+  // where a custom template *might* exist: /path/to/app/web/generators/page/page.tsx.template
+  const customPath = path.join(
+    getPaths()[side].generators,
+    generator,
+    templatePath,
+  )
+
+  if (fs.existsSync(customPath)) {
+    return customPath
+  } else {
+    return defaultPath
+  }
+}
+
+/**
+ * Reduces boilerplate for generating an output path and content to write to disk
+ * for a component.
+ */
+// TODO: Make this read all the files in a template directory instead of
+// manually passing in each file.
+export const templateForComponentFile = async ({
+  name,
+  suffix = '',
+  extension = '.js',
+  webPathSection,
+  apiPathSection,
+  generator,
+  templatePath,
+  templateVars,
+  componentName,
+  outputPath,
+}) => {
+  const basePath = webPathSection
+    ? getPaths().web[webPathSection]
+    : getPaths().api[apiPathSection]
+  const outputComponentName = componentName || pascalcase(name) + suffix
+  const componentOutputPath =
+    outputPath ||
+    path.join(basePath, outputComponentName, outputComponentName + extension)
+  const fullTemplatePath = customOrDefaultTemplatePath({
+    generator,
+    templatePath,
+    side: webPathSection ? 'web' : 'api',
+  })
+  const content = await generateTemplate(fullTemplatePath, {
+    name,
+    outputPath: ensurePosixPath(
+      `./${path.relative(getPaths().base, componentOutputPath)}`,
+    ),
+    ...templateVars,
+  })
+  return [componentOutputPath, content]
+}
+
+export const validateName = (name) => {
+  if (name.match(/^\W/)) {
+    throw new Error(
+      'The <name> argument must start with a letter, number or underscore.',
+    )
+  }
+}
+
+export function createHandler({
+  componentName,
+  preTasksFn,
+  filesFn,
+  includeAdditionalTasks,
+}) {
+  return async (options) => {
+    recordTelemetryAttributes({
+      command: `generate ${componentName}`,
+      tests: options.tests,
+      stories: options.stories,
+      verbose: options.verbose,
+      rollback: options.rollback,
+      force: options.force,
+      // TODO: This does not cover the specific options that each generator might pass in
+    })
+
+    if (options.tests === undefined) {
+      options.tests = getConfig().generate.tests
+    }
+    if (options.stories === undefined) {
+      options.stories = getConfig().generate.stories
+    }
+    validateName(options.name)
+
+    try {
+      options = await preTasksFn(options)
+
+      const tasks = new Listr(
+        [
+          {
+            title: `Generating ${componentName} files...`,
+            task: async () => {
+              const f = await filesFn(options)
+              return writeFilesTask(f, { overwriteExisting: options.force })
+            },
+          },
+          ...includeAdditionalTasks(options),
+        ],
+        {
+          rendererOptions: { collapseSubtasks: false },
+          exitOnError: true,
+          renderer: options.verbose && 'verbose',
+        },
+      )
+
+      if (options.rollback && !options.force) {
+        prepareForRollback(tasks)
+      }
+      await tasks.run()
+    } catch (e) {
+      errorTelemetry(process.argv, e.message)
+      console.error(c.error(e.message))
+      process.exit(e?.exitCode || 1)
+    }
+  }
+}
+
+// TODO: Remove this function. This is only temporarily to be able to split one
+// command at a time into a separate async handler
+/**
+ * Reduces boilerplate for creating a yargs handler that writes a
+ * component/page/layout/etc to a location.
+ */
+export const createYargsForComponentGeneration = ({
+  componentName,
+  preTasksFn = (options) => options,
+  /** filesFn is not used if generator implements its own `handler` */
+  filesFn = () => ({}),
+  optionsObj = yargsDefaults,
+  positionalsObj = {},
+  /** function that takes the options object and returns an array of listr tasks */
+  includeAdditionalTasks = () => [],
+}) => {
+  return {
+    command: createCommand(componentName, positionalsObj),
+    description: createDescription(componentName),
+    builder: createBuilder({ componentName, optionsObj, positionalsObj }),
+    handler: createHandler({
+      componentName,
+      preTasksFn,
+      filesFn,
+      includeAdditionalTasks,
+    }),
+  }
+}


### PR DESCRIPTION
When moving to ESM we have to get rid of yargs' `.commandDir()` and instead `import` all files. When doing so we also have to split each command out into a separate handler() function that asynchronously imports things to not bloat the CLI and to not trigger unwanted side effects from imports (some imports run code just by being imported).

This PR preps for all of that by splitting up the cell generator as a proof of concept. It also splits a helper file into three separate files, two which are safe to sync import in the CLI and one which has to be async imported.