### PR TITLE
docs(babel-config): Add jsdocs to index exports

### DIFF
--- a/.changesets/31.md
+++ b/.changesets/31.md
@@ -1,0 +1,5 @@
+- docs(babel-config): Add jsdocs to index exports (#31) by @Tobbe
+
+If you import from `@redmix/babel-config` you might now get a deprecation
+warning in your editor. Please let us know if you use any of these exports and
+we can discuss whether to keep it around or if there's a better solution.

--- a/packages/babel-config/src/index.ts
+++ b/packages/babel-config/src/index.ts
@@ -3,33 +3,90 @@
 // See https://github.com/redwoodjs/redwood/blob/44b4a9023ac3a14b5f56b071052bdf49c410bb8b/packages/internal/src/index.ts#L13-L16.
 
 export {
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   BABEL_PLUGIN_TRANSFORM_RUNTIME_OPTIONS,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   TARGETS_NODE,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   getApiSideBabelConfigPath,
+  /** Used by @redmix/internal and @redmix/testing */
   getApiSideBabelPlugins,
+  /** Used by @redmix/testing */
   getApiSideBabelPresets,
+  /** Used by @redmix/testing and @redmix/eslint-config */
   getApiSideDefaultBabelConfig,
+  /** Used by @redmix/cli, @remix/cli-helpers and @redmix/prerender */
   registerApiSideBabelHook,
+  /** Used by @redmix/internal and @redmix/vite */
   transformWithBabel,
 } from './api'
 
 export {
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   getWebSideBabelConfigPath,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   getWebSideBabelPlugins,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   getWebSideBabelPresets,
+  /** Used by @redmix/cli, @remix/eslint-config and @redmix/vite */
   getWebSideDefaultBabelConfig,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   getWebSideOverrides,
+  /** Used by @redmix/prerender */
   registerWebSideBabelHook,
 } from './web'
 
 export type { Flags } from './web'
 
 export {
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   CORE_JS_VERSION,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   RUNTIME_CORE_JS_VERSION,
+  /** Used by our eslint-config  */
   getCommonPlugins,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   getPathsFromTypeScriptConfig as getPathsFromConfig,
+  /** Used by vite */
   getRouteHookBabelPlugins,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   parseTypeScriptConfigFiles,
+  /**
+   * @deprecated This export isn't used by the framework, so it'll be removed
+   * in a future version.
+   */
   registerBabel,
 } from './common'


### PR DESCRIPTION
We've been exporting a bunch of unnecessary stuff to keep backwards compatibility. This PR adds jsdocs to all exports marking those we don't use ourselves as deprecated. 

If you import from `@redmix/babel-config` you might get a deprecation warning in your editor.
Please let us know if you use any of these exports and we can discuss whether to keep it around or if there's a better solution.