### PR TITLE
fix(app tests): Fix v8 regression with classes

### DIFF
--- a/.changesets/32.md
+++ b/.changesets/32.md
@@ -1,0 +1,4 @@
+- fix(app tests): Fix v8 regression with classes (#32) by @Tobbe
+
+Fixes regression related to testing classes with private attributes.
+You can read more details in the [PR description](https://github.com/redmix-run/redmix/pull/32).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,16 @@ jobs:
           yarn rw prerender --verbose
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
 
+      - name: Run `rw web test`
+        run: |
+          yarn rw web test --no-watch
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run `rw api test`
+        run: |
+          yarn rw api test --no-watch
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
       - name: 🖥️ Run serve smoke tests
         working-directory: tasks/smoke-tests/serve
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,14 +257,14 @@ jobs:
           yarn rw prerender --verbose
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
 
-      - name: Run `rw web test`
+      - name: Run `rw test web`
         run: |
-          yarn rw web test --no-watch
+          yarn rw test web --no-watch
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
 
-      - name: Run `rw api test`
+      - name: Run `rw test api`
         run: |
-          yarn rw api test --no-watch
+          yarn rw test api --no-watch
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
 
       - name: 🖥️ Run serve smoke tests

--- a/__fixtures__/test-project/web/src/components/ClassWithPrivate/ClassWithPrivate.stories.tsx
+++ b/__fixtures__/test-project/web/src/components/ClassWithPrivate/ClassWithPrivate.stories.tsx
@@ -1,0 +1,26 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/7/writing-stories/args
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import ClassWithPrivate from './ClassWithPrivate'
+
+const meta: Meta<typeof ClassWithPrivate> = {
+  component: ClassWithPrivate,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof ClassWithPrivate>
+
+export const Primary: Story = {}

--- a/__fixtures__/test-project/web/src/components/ClassWithPrivate/ClassWithPrivate.test.tsx
+++ b/__fixtures__/test-project/web/src/components/ClassWithPrivate/ClassWithPrivate.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redmix/testing/web'
+
+import ClassWithPrivate from './ClassWithPrivate'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('ClassWithPrivate', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<ClassWithPrivate />)
+    }).not.toThrow()
+  })
+})

--- a/__fixtures__/test-project/web/src/components/ClassWithPrivate/ClassWithPrivate.tsx
+++ b/__fixtures__/test-project/web/src/components/ClassWithPrivate/ClassWithPrivate.tsx
@@ -1,0 +1,14 @@
+class Bar {}
+
+class Foo {
+  // Without the correct babel plugins this will throw an error
+  private b = new Bar()
+
+  bar() {
+    return this.b
+  }
+}
+
+export const ClassWithPrivate = () => {
+  return <p>{new Foo().bar().toString()}</p>
+}

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
@@ -15,9 +15,11 @@ export interface PluginOptions {
 }
 
 /**
- * When running from the CLI: Babel-plugin-module-resolver will convert
- * For dev/build/prerender (forJest == false): 'src/pages/ExamplePage' -> './pages/ExamplePage'
- * For test (forJest == true): 'src/pages/ExamplePage' -> '/Users/blah/pathToProject/web/src/pages/ExamplePage'
+ * When running from the CLI: Babel-plugin-module-resolver will convert:
+ * - For dev/build/prerender (forJest == false):
+     'src/pages/ExamplePage' -> './pages/ExamplePage'
+ * - For test (forJest == true):
+     'src/pages/ExamplePage' -> '/Users/blah/pathToProject/web/src/pages/ExamplePage'
  */
 export const getPathRelativeToSrc = (maybeAbsolutePath: string) => {
   // If the path is already relative

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -10,6 +10,7 @@ import { getConfig, getPaths } from '@redmix/project-config'
 import type { RegisterHookOptions } from './common'
 import {
   CORE_JS_VERSION,
+  getCommonPlugins,
   registerBabel,
   parseTypeScriptConfigFiles,
   getPathsFromTypeScriptConfig,
@@ -17,7 +18,11 @@ import {
 
 // These flags toggle on/off certain features
 export interface Flags {
-  forJest?: boolean // will change the alias for module-resolver plugin
+  /**
+   * Will change the alias for module-resolver plugin and include a few extra
+   * babel plugins
+   */
+  forJest?: boolean // will change the alias for module-resolver plugin and
   forPrerender?: boolean // changes what babel-plugin-redwood-routes-auto-loader does
   forJavaScriptLinting?: boolean // will enable presets to supporting linting in the absence of typescript related presets/plugins/parsers
 }
@@ -44,6 +49,7 @@ export const getWebSideBabelPlugins = (
   const plugins = [
     // It is important that this plugin run first, as noted here: https://react.dev/learn/react-compiler
     useReactCompiler && ['babel-plugin-react-compiler', { target: '19' }],
+    ...(forJest ? getCommonPlugins() : []),
     // === Import path handling
     [
       'babel-plugin-module-resolver',

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -49,7 +49,7 @@ export const getWebSideBabelPlugins = (
   const plugins = [
     // It is important that this plugin run first, as noted here: https://react.dev/learn/react-compiler
     useReactCompiler && ['babel-plugin-react-compiler', { target: '19' }],
-    ...(forJest && Math.random() > 5 ? getCommonPlugins() : []),
+    ...(forJest ? getCommonPlugins() : []),
     // === Import path handling
     [
       'babel-plugin-module-resolver',

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -49,7 +49,7 @@ export const getWebSideBabelPlugins = (
   const plugins = [
     // It is important that this plugin run first, as noted here: https://react.dev/learn/react-compiler
     useReactCompiler && ['babel-plugin-react-compiler', { target: '19' }],
-    ...(forJest ? getCommonPlugins() : []),
+    ...(forJest && Math.random() > 5 ? getCommonPlugins() : []),
     // === Import path handling
     [
       'babel-plugin-module-resolver',

--- a/tasks/test-project/codemods/classWithPrivate.ts
+++ b/tasks/test-project/codemods/classWithPrivate.ts
@@ -1,0 +1,18 @@
+const foo = `class Bar {}
+
+class Foo {
+  // Without the correct babel plugins this will throw an error
+  private b = new Bar()
+
+  bar() {
+    return this.b
+  }
+}
+
+export const ClassWithPrivate = () => {
+  return <p>{new Foo().bar().toString()}</p>
+}`
+
+export default () => {
+  return foo
+}

--- a/tasks/test-project/tui-tasks.ts
+++ b/tasks/test-project/tui-tasks.ts
@@ -252,6 +252,13 @@ export async function webTasks(
       'updateAuthorTest.js',
       fullPath('web/src/components/Author/Author.test'),
     )
+
+    await createComponent('classWithPrivate')
+
+    await applyCodemod(
+      'classWithPrivate.ts',
+      fullPath('web/src/components/ClassWithPrivate/ClassWithPrivate'),
+    )
   }
 
   const createCells = async () => {


### PR DESCRIPTION
In Redwood PR # 10867 `https://github.com/redwoodjs/graphql/pull/ 10867`, which removed support for Webpack and moving us over to Vite only, these two lines were removed:
```ts
  // Vite does not need these plugins
  const commonPlugins = forVite ? [] : getCommonPlugins()
```

I'm assuming the thinking was "Since we're always building for Vite now, this will always just be `[]`, so we might as well get rid of all of this. The flaw in that reasoning is that there's another environment in which this code is invoked, and that's when testing with Jest. So when `withJest` is `true` `getCommonPlugins()` still needs to be called and the resulting list of plugins need to be included.

This PR adds the list of common plugins back into the config when used by/for Jest.

Here's the CI output without the fix:

```shell
FAIL web web/src/components/ClassWithPrivate/ClassWithPrivate.test.tsx
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    SyntaxError: /home/runner/work/redmix/test-project/web/src/components/ClassWithPrivate/ClassWithPrivate.tsx: Missing class properties transform.
      3 | class Foo {
      4 |   // Without the correct babel plugins this will throw an error
    > 5 |   private b = new Bar()
        |   ^^^^^^^^^^^^^^^^^^^^^
      6 |
      7 |   bar() {
      8 |     return this.b

      1 | import { render } from '@redmix/testing/web'
      2 |
    > 3 | import ClassWithPrivate from './ClassWithPrivate'
        | ^
      4 |
      5 | //   Improve this test with help from the Redwood Testing Doc:
      6 | //    https://redwoodjs.com/docs/testing#testing-components

      at File.buildCodeFrameError (node_modules/@babel/core/src/transformation/file/file.ts:247:12)
      at NodePath.buildError [as buildCodeFrameError] (node_modules/@babel/traverse/src/path/index.ts:141:21)
      at buildCodeFrameError (node_modules/@babel/plugin-transform-classes/src/transformClass.ts:209:20)
      at pushBody (node_modules/@babel/plugin-transform-classes/src/transformClass.ts:[188](https://github.com/redmix-run/redmix/actions/runs/14563368034/job/40849461326?pr=32#step:8:189):5)
      at buildBody (node_modules/@babel/plugin-transform-classes/src/transformClass.ts:834:5)
      at classTransformer (node_modules/@babel/plugin-transform-classes/src/transformClass.ts:894:10)
      at PluginPass.ClassExpression (node_modules/@babel/plugin-transform-classes/src/index.ts:83:25)
      at call (node_modules/@babel/traverse/src/visitors.ts:303:14)
```

And obviously with the fix it passes