### PR TITLE
refactor(cli): createHandler() command helper

### DIFF
--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -3,6 +3,7 @@ import {
   createDescription,
   createBuilder,
   yargsDefaults,
+  createHandler,
 } from '../yargsCommandHelpers.js'
 
 export const command = createCommand('cell')
@@ -26,9 +27,4 @@ export const builder = createBuilder({
     },
   },
 })
-
-export async function handler(argv) {
-  const { handler: cellHandler } = await import('./cellHandler.js')
-
-  return cellHandler(argv)
-}
+export const handler = createHandler('cell')

--- a/packages/cli/src/commands/generate/component/component.js
+++ b/packages/cli/src/commands/generate/component/component.js
@@ -1,11 +1,10 @@
-import { createCommand, createBuilder } from '../yargsCommandHelpers.js'
+import {
+  createCommand,
+  createBuilder,
+  createHandler,
+} from '../yargsCommandHelpers.js'
 
 export const command = createCommand('component')
 export const description = 'Generate a component'
 export const builder = createBuilder({ componentName: 'component' })
-
-export async function handler(argv) {
-  const { handler: componentHandler } = await import('./componentHandler.js')
-
-  return componentHandler(argv)
-}
+export const handler = createHandler('component')

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -1,6 +1,6 @@
 import terminalLink from 'terminal-link'
 
-import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { yargsDefaults, createHandler } from '../yargsCommandHelpers.js'
 
 export const command = 'dbAuth'
 export const description =
@@ -60,9 +60,4 @@ export const builder = (yargs) => {
     yargs.option(option, config)
   })
 }
-
-export async function handler(argv) {
-  const { handler: dbAuthHandler } = await import('./dbAuthHandler.js')
-
-  return dbAuthHandler(argv)
-}
+export const handler = createHandler('dbAuth')

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -1,28 +1,10 @@
 import {
-  createCommand,
   createBuilder,
-  yargsDefaults,
+  createCommand,
+  createHandler,
 } from '../yargsCommandHelpers.js'
-import { createYargsForComponentGeneration } from '../yargsHandlerHelpers.js'
 
 export const command = createCommand('directive')
 export const description = 'Generate a new GraphQL directive'
 export const builder = createBuilder({ componentName: 'directive' })
-
-createYargsForComponentGeneration({
-  componentName: 'directive',
-  optionsObj: {
-    ...yargsDefaults,
-    type: {
-      type: 'string',
-      choices: ['validator', 'transformer'],
-      description: 'Whether to generate a validator or transformer directive',
-    },
-  },
-})
-
-export async function handler(argv) {
-  const { handler: directiveHandler } = await import('./directiveHandler.js')
-
-  return directiveHandler(argv)
-}
+export const handler = createHandler('directive')

--- a/packages/cli/src/commands/generate/function/function.js
+++ b/packages/cli/src/commands/generate/function/function.js
@@ -1,6 +1,6 @@
 import terminalLink from 'terminal-link'
 
-import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { yargsDefaults, createHandler } from '../yargsCommandHelpers.js'
 
 export const command = 'function <name>'
 export const description = 'Generate a Function'
@@ -33,8 +33,4 @@ export const builder = (yargs) => {
   })
 }
 
-export async function handler(argv) {
-  const { handler: importedHandler } = await import('./functionHandler.js')
-
-  return importedHandler(argv)
-}
+export const handler = createHandler('function')

--- a/packages/cli/src/commands/generate/job/job.js
+++ b/packages/cli/src/commands/generate/job/job.js
@@ -1,7 +1,7 @@
 import terminalLink from 'terminal-link'
 
 import { isTypeScriptProject } from '../../../lib/project.js'
-import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { yargsDefaults, createHandler } from '../yargsCommandHelpers.js'
 
 export const command = 'job <name>'
 export const description = 'Generate a Background Job'
@@ -47,8 +47,4 @@ export const builder = (yargs) => {
   })
 }
 
-export async function handler(argv) {
-  const { handler: importedHandler } = await import('./jobHandler.js')
-
-  return importedHandler(argv)
-}
+export const handler = createHandler('job')

--- a/packages/cli/src/commands/generate/layout/layout.js
+++ b/packages/cli/src/commands/generate/layout/layout.js
@@ -2,6 +2,7 @@ import {
   createCommand,
   createDescription,
   createBuilder,
+  createHandler,
   yargsDefaults,
 } from '../yargsCommandHelpers.js'
 
@@ -17,9 +18,4 @@ const optionsObj = {
 export const command = createCommand('layout')
 export const description = createDescription('layout')
 export const builder = createBuilder({ componentName: 'layout', optionsObj })
-
-export async function handler(argv) {
-  const { handler: importedHandler } = await import('./layoutHandler.js')
-
-  return importedHandler(argv)
-}
+export const handler = createHandler('layout')

--- a/packages/cli/src/commands/generate/model/model.js
+++ b/packages/cli/src/commands/generate/model/model.js
@@ -1,6 +1,6 @@
 import terminalLink from 'terminal-link'
 
-import { yargsDefaults } from '../yargsCommandHelpers.js'
+import { createHandler, yargsDefaults } from '../yargsCommandHelpers.js'
 
 export const command = 'model <name>'
 export const description = 'Generate a RedwoodRecord model'
@@ -26,9 +26,4 @@ export const builder = (yargs) => {
     yargs.option(option, config)
   })
 }
-
-export async function handler(argv) {
-  const { handler: importedHandler } = await import('./modelHandler.js')
-
-  return importedHandler(argv)
-}
+export const handler = createHandler('model')

--- a/packages/cli/src/commands/generate/ogImage/ogImage.js
+++ b/packages/cli/src/commands/generate/ogImage/ogImage.js
@@ -1,12 +1,11 @@
 import terminalLink from 'terminal-link'
 
 import { isTypeScriptProject } from '../../../lib/project.js'
+import { createHandler } from '../yargsCommandHelpers.js'
 
 export const description = 'Generate an og:image component'
-
 export const command = 'og-image <path>'
 export const aliases = ['ogImage', 'ogimage']
-
 export const builder = (yargs) => {
   yargs
     .positional('path', {
@@ -42,9 +41,4 @@ export const builder = (yargs) => {
       default: true,
     })
 }
-
-export async function handler(argv) {
-  const { handler: importedHandler } = await import('./ogImageHandler.js')
-
-  return importedHandler(argv)
-}
+export const handler = createHandler('ogImage')

--- a/packages/cli/src/commands/generate/yargsCommandHelpers.js
+++ b/packages/cli/src/commands/generate/yargsCommandHelpers.js
@@ -88,3 +88,13 @@ export function createBuilder({
     })
   }
 }
+
+export function createHandler(componentName) {
+  return async function handler(argv) {
+    const { handler: importedHandler } = await import(
+      `./${componentName}Handler.js`
+    )
+
+    return importedHandler(argv)
+  }
+}

--- a/packages/cli/src/commands/generate/yargsCommandHelpers.js
+++ b/packages/cli/src/commands/generate/yargsCommandHelpers.js
@@ -92,7 +92,7 @@ export function createBuilder({
 export function createHandler(componentName) {
   return async function handler(argv) {
     const { handler: importedHandler } = await import(
-      `./${componentName}Handler.js`
+      `./${componentName}/${componentName}Handler.js`
     )
 
     return importedHandler(argv)


### PR DESCRIPTION
Provide a convenience helper for creating command handlers that asynchronously imports the handler function when invoked.