### PR TITLE
fix(cli/setup): Fix Tailwind setup to work with Storybook

### DIFF
--- a/.changesets/42.md
+++ b/.changesets/42.md
@@ -1,0 +1,4 @@
+- fix(cli/setup): Fix Tailwind setup to work with Storybook (#42) by @Tobbe
+
+⚠️ If you've already got Tailwind setup, you have to perform this change
+manually. Look at the diff in the PR and just copy the changes.

--- a/__fixtures__/test-project/web/config/tailwind.config.js
+++ b/__fixtures__/test-project/web/config/tailwind.config.js
@@ -1,6 +1,8 @@
+const { join } = require('node:path')
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['src/**/*.{js,jsx,ts,tsx}'],
+  content: [join(__dirname, '../src/**/*.{js,jsx,ts,tsx}')],
   theme: {
     extend: {},
   },

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -228,10 +228,12 @@ export const handler = async ({ force, install }) => {
 
           // Replace `content`.
           const tailwindConfig = fs.readFileSync(tailwindConfigPath, 'utf-8')
-          const newTailwindConfig = tailwindConfig.replace(
-            'content: []',
-            "content: ['src/**/*.{js,jsx,ts,tsx}']",
-          )
+          const newTailwindConfig =
+            'const { join } = require("node:path");\n\n' +
+            tailwindConfig.replace(
+              'content: []',
+              "content: [join(__dirname, '../src/**/*.{js,jsx,ts,tsx}')]",
+            )
           fs.writeFileSync(tailwindConfigPath, newTailwindConfig)
         },
       },


### PR DESCRIPTION
Use an absolute path so Tailwind also works for Storybook components