### PR TITLE
fix(crxa): Remove comment referencing dbAuth

### DIFF
--- a/__fixtures__/test-project/redwood.toml
+++ b/__fixtures__/test-project/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://redwoodjs.com/docs/environment-variables#web

--- a/packages/create-redmix-app/templates/js/redwood.toml
+++ b/packages/create-redmix-app/templates/js/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://redwoodjs.com/docs/environment-variables#web

--- a/packages/create-redmix-app/templates/ts/redwood.toml
+++ b/packages/create-redmix-app/templates/ts/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://redwoodjs.com/docs/environment-variables#web


### PR DESCRIPTION
Not all projects will use dbAuth, so shouldn't mention it in the redwood.toml file every project gets.

This change only updates our templates. Does not affect existing projects. And no need for any existing projects to make any changes.