### PR TITLE
chore(api): Only async version consts

### DIFF
--- a/packages/api/build.mts
+++ b/packages/api/build.mts
@@ -30,22 +30,10 @@ await build({
   },
 })
 
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
-
 // Place a package.json file with `type: commonjs` in the dist/cjs folder so
 // that all .js files are treated as CommonJS files.
 fs.writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
 
 // Place a package.json file with `type: module` in the dist folder so that
 // all .js files are treated as ES Module files.
-// Also adding version and dependencies so that src/index.ts for the CJS build
-// can read those (The relative ../package.json path in the index.ts file will
-// point to this file)
-fs.writeFileSync(
-  'dist/package.json',
-  JSON.stringify({
-    type: 'module',
-    version: packageJson.version,
-    dependencies: packageJson.dependencies,
-  }),
-)
+fs.writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))

--- a/packages/api/build.mts
+++ b/packages/api/build.mts
@@ -24,13 +24,6 @@ await build({
   },
   buildOptions: {
     ...defaultBuildOptions,
-    banner: {
-      js:
-        'import bannerPath from "node:path"; ' +
-        'import bannerUrl from "node:url"; ' +
-        'const __filename = bannerUrl.fileURLToPath(import.meta.url); ' +
-        'const __dirname = bannerPath.dirname(__filename);',
-    },
     tsconfig: 'tsconfig.build.json',
     format: 'esm',
     packages: 'external',

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module'
+
 export * from './auth/index.js'
 export * from './errors.js'
 export * from './validations/validations.js'
@@ -7,23 +9,14 @@ export * from './transforms.js'
 export * from './cors.js'
 export * from './event.js'
 
-// Keeping original functionality for CJS builds to stay 100% backwards
-// compatible
-const packageJson =
-  typeof require === 'function' ? require('../package.json') : {}
-export const prismaVersion = packageJson?.dependencies?.['@prisma/client']
+const customRequire =
+  typeof require === 'function'
+    ? require
+    : createRequire(process.env.RWJS_CWD || process.cwd())
+
+const rxApiPath = customRequire.resolve('@redmix/api')
+const rxApiRequire = customRequire(rxApiPath)
+
+const packageJson = rxApiRequire('./package.json')
+export const prismaVersion = packageJson?.dependencies['@prisma/client']
 export const redwoodVersion = packageJson?.version
-
-// Adding this as a fallback for ESM builds
-export async function getPrismaVersion() {
-  const { default: apiPackageJson } = await import('@redmix/api/package.json')
-
-  return apiPackageJson?.dependencies?.['@prisma/client']
-}
-
-// Adding this as a fallback for ESM builds
-export async function getRedwoodVersion() {
-  const { default: apiPackageJson } = await import('@redmix/api/package.json')
-
-  return apiPackageJson?.version
-}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,14 +9,8 @@ export * from './transforms.js'
 export * from './cors.js'
 export * from './event.js'
 
-const customRequire =
-  typeof require === 'function'
-    ? require
-    : createRequire(process.env.RWJS_CWD || process.cwd())
+const customRequire = createRequire(process.env.RWJS_CWD || process.cwd())
 
-const rxApiPath = customRequire.resolve('@redmix/api')
-const rxApiRequire = customRequire(rxApiPath)
-
-const packageJson = rxApiRequire('./package.json')
+const packageJson = customRequire('@redmix/api/package.json')
 export const prismaVersion = packageJson?.dependencies['@prisma/client']
 export const redwoodVersion = packageJson?.version

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,8 +9,25 @@ export * from './transforms.js'
 export * from './cors.js'
 export * from './event.js'
 
-const customRequire = createRequire(process.env.RWJS_CWD || process.cwd())
+const customRequire =
+  typeof require === 'function'
+    ? require
+    : createRequire(process.env.RWJS_CWD || process.cwd())
 
-const packageJson = customRequire('@redmix/api/package.json')
+const rxApiPath = customRequire.resolve('@redmix/api')
+const rxApiRequire = createRequire(rxApiPath)
+
+let packageJson = rxApiRequire('./package.json')
+
+// Because of how we build the package we might have to walk up the directory
+// tree a few times to find the correct package.json file
+if (packageJson?.name !== '@redmix/api') {
+  packageJson = rxApiRequire('../package.json')
+}
+
+if (packageJson?.name !== '@redmix/api') {
+  packageJson = rxApiRequire('../../package.json')
+}
+
 export const prismaVersion = packageJson?.dependencies['@prisma/client']
 export const redwoodVersion = packageJson?.version

--- a/packages/graphql-server/src/rootSchema.ts
+++ b/packages/graphql-server/src/rootSchema.ts
@@ -9,12 +9,7 @@ import {
 } from 'graphql-scalars'
 import gql from 'graphql-tag'
 
-import {
-  prismaVersion,
-  redwoodVersion,
-  getPrismaVersion,
-  getRedwoodVersion,
-} from '@redmix/api'
+import { prismaVersion, redwoodVersion } from '@redmix/api'
 import type { GlobalContext } from '@redmix/context'
 
 /**
@@ -82,15 +77,13 @@ export const resolvers: Resolvers = {
   JSON: JSONResolver,
   JSONObject: JSONObjectResolver,
   Query: {
-    redwood: async () => {
-      return {
-        version: redwoodVersion || (await getRedwoodVersion()),
-        prismaVersion: prismaVersion || (await getPrismaVersion()),
-        currentUser: (_args: any, context: GlobalContext) => {
-          return context?.currentUser
-        },
-      }
-    },
+    redwood: () => ({
+      version: redwoodVersion,
+      prismaVersion: prismaVersion,
+      currentUser: (_args: any, context: GlobalContext) => {
+        return context?.currentUser
+      },
+    }),
   },
   Byte: ByteResolver,
 }


### PR DESCRIPTION
Testing a new approach that tries to stick closer to the original by just using `require`, but doing so in a way that works for both CJS and ESM.

This reverts a bunch of the changes made in #45 plus all of https://github.com/redmix-run/redmix/commit/3646c569f88779afd28318ade78545b64081a196