### PR TITLE
fix(graphql-server): Don't require healthCheckId

### DIFF
--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -551,7 +551,7 @@ Note the `x-yoga-id` header. The header's value defaults to `yoga` when `healthC
 export const handler = createGraphQLHandler({
   // This will be the value of the `x-yoga-id` header
   // highlight-next-line
-  healthCheckId: 'my-Redmix-graphql-server',
+  healthCheckId: 'my-redmix-graphql-server',
   getCurrentUser,
   loggerConfig: { logger, options: {} },
   directives,

--- a/packages/graphql-server/src/__tests__/createGraphQLYoga.test.ts
+++ b/packages/graphql-server/src/__tests__/createGraphQLYoga.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { createLogger } from '@redmix/api/logger'
+
+import { createGraphQLYoga } from '../createGraphQLYoga'
+
+describe('createGraphQLYoga smoke-test', () => {
+  it('Should only require required parameters', () => {
+    const { logger, yoga } = createGraphQLYoga({
+      loggerConfig: { logger: createLogger({}) },
+      sdls: {},
+      services: {},
+    })
+
+    expect(logger).toBeTruthy()
+    expect(yoga).toBeTruthy()
+  })
+})

--- a/packages/graphql-server/src/createGraphQLYoga.ts
+++ b/packages/graphql-server/src/createGraphQLYoga.ts
@@ -30,7 +30,7 @@ import type { RedwoodSubscription } from './subscriptions/makeSubscriptions'
 import type { GraphQLYogaOptions } from './types'
 
 export const createGraphQLYoga = ({
-  healthCheckId,
+  healthCheckId = 'yoga',
   loggerConfig,
   context,
   getCurrentUser,
@@ -168,12 +168,10 @@ export const createGraphQLYoga = ({
               new URL(graphiQLEndpoint + '/health', request.url),
             )
 
-            const expectedHealthCheckId = healthCheckId || 'yoga'
-
-            // ... and the health check id's match the request and response's
+            // ... and the health check id match the request's and response's
             const status =
-              response.headers.get('x-yoga-id') === expectedHealthCheckId &&
-              request.headers.get('x-yoga-id') === expectedHealthCheckId
+              response.headers.get('x-yoga-id') === healthCheckId &&
+              request.headers.get('x-yoga-id') === healthCheckId
 
             // then we're good to go (or not)
             return status


### PR DESCRIPTION
`createGraphQLYoga` should not crash if optional parameters are not provided