### PR TITLE
fix(api-server): Allow fully custom graphql function

### DIFF
--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -131,7 +131,8 @@ export async function createServer(options: CreateServerOptions = {}) {
 
   if (graphqlFunctionPath) {
     const { redwoodFastifyGraphQLServer } = await import('./plugins/graphql.js')
-    // This comes from a babel plugin that's applied to api/dist/functions/graphql.{ts,js} in user projects
+    // This comes from a babel plugin that's applied to
+    // api/dist/functions/graphql.{ts,js} in user projects
     const { __rw_graphqlOptions } = await import(
       `file://${graphqlFunctionPath}`
     )

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-graphql-options-extract.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-graphql-options-extract.ts
@@ -1,6 +1,7 @@
 import type { NodePath, PluginObj, PluginPass, types } from '@babel/core'
 
-// This extracts the options passed to the graphql function and stores them in an exported variable so they can be imported elsewhere.
+// This extracts the options passed to the graphql function and stores them in
+// an exported variable so they can be imported elsewhere.
 
 const exportVariableName = '__rw_graphqlOptions'
 
@@ -70,12 +71,17 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
             }
           },
         })
+
         if (callExpressionPaths.length > 1) {
           console.log(
-            `There are ${callExpressionPaths.length} calls to 'createGraphQLHandler' in '${state.file.opts.filename}'. The automatic extraction of graphql options will fallback to the first usage.`,
+            `There are ${callExpressionPaths.length} calls to ` +
+              `'createGraphQLHandler' in '${state.file.opts.filename}'. The ` +
+              'automatic extraction of graphql options will fallback to the ' +
+              'first usage.',
           )
           return
         }
+
         const callExpressionPath = callExpressionPaths[0]
         if (!callExpressionPath) {
           return


### PR DESCRIPTION
https://github.com/redwoodjs/graphql/pull/9845 introduced a babel plugin to extract the options that are passed to `createGraphQLHandler` into an internal variable `__rw_graphqlOptions`.

If no options to extract could be found the variable would not be created. 

In `@redmix/graphql-server` this would lead to passing `undefined` to `createGraphQLYoga()`, which in turn would cause an exception to be thrown that we'd catch and log.

With this PR we assume the user is doing their own thing that they want full control over. So instead of trying to create a Redmix gql handler and failing, we instead entirely just skip our own handling if no `__rw_graphqlOptions` variable is exported