### PR TITLE
fix(exec): Honor --silent for prisma client generation step

### DIFF
--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -161,7 +161,7 @@ export const handler = async (args) => {
     {
       title: 'Generating Prisma client',
       enabled: () => prisma,
-      task: () => generatePrismaClient({ force: false }),
+      task: () => generatePrismaClient({ force: false, verbose: !args.silent }),
     },
     {
       title: 'Running script',


### PR DESCRIPTION
Pass the `--silent` option onwards to `generatePrismaClient` so that the user's will to silence the output is honored for that step as well