### PR TITLE
feat(cli): await import Prisma client to support ESM

### DIFF
--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -44,15 +44,22 @@ export const generatePrismaClient = async ({
   if (!force) {
     // The Prisma client throws if it is not generated.
     try {
-      // Import the client from the redwood apps node_modules path.
-      const { PrismaClient } = require(
-        path.join(getPaths().base, 'node_modules/.prisma/client'),
+      // Import the client from the Redmix app's node_modules path.
+      const { PrismaClient } = await import(
+        path.join(getPaths().base, 'node_modules/.prisma/client/index.js')
       )
+
       // eslint-disable-next-line
       new PrismaClient()
-      return // Client exists, so abort.
+
+      // Client exists, so abort.
+      return
     } catch (e) {
-      // Swallow your pain, and generate.
+      // Client does not exist, continue execution
+      // TODO: Look for the expected error message. If we get another error we
+      // should print it
+      // Expecting:
+      // Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
     }
   }
 

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -48,7 +48,6 @@ export const generatePrismaClient = async ({
         getPaths().base,
         'node_modules/.prisma/client/index.js',
       )
-      console.log('Prisma client path', prismaClientPath)
 
       // Import the client from the Redmix app's node_modules path.
       const { PrismaClient } = await import(prismaClientPath)
@@ -60,8 +59,9 @@ export const generatePrismaClient = async ({
       return
     } catch (e) {
       // Client does not exist, continue execution
-      // TODO: Look for the expected error message. If we get another error we
-      // should print it
+      //
+      // TODO: Look for the specific error message we expect. If we get another
+      // error we should print it
       // Expecting:
       // Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
     }

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -67,7 +67,7 @@ export const generatePrismaClient = async ({
     }
   }
 
-  return await runCommandTask(
+  await runCommandTask(
     [
       {
         title: 'Generating the Prisma client...',
@@ -79,4 +79,15 @@ export const generatePrismaClient = async ({
       silent,
     },
   )
+
+  // Purge Prisma Client from node's require cache, so that the newly generated
+  // client gets picked up by any script that uses it
+  Object.keys(require.cache).forEach((key) => {
+    if (
+      key.includes('/node_modules/@prisma/client/') ||
+      key.includes('/node_modules/.prisma/client/')
+    ) {
+      delete require.cache[key]
+    }
+  })
 }

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -44,10 +44,14 @@ export const generatePrismaClient = async ({
   if (!force) {
     // The Prisma client throws if it is not generated.
     try {
-      // Import the client from the Redmix app's node_modules path.
-      const { PrismaClient } = await import(
-        path.join(getPaths().base, 'node_modules/.prisma/client/index.js')
+      const prismaClientPath = path.join(
+        getPaths().base,
+        'node_modules/.prisma/client/index.js',
       )
+      console.log(`Prisma client path: ${prismaClientPath}`)
+
+      // Import the client from the Redmix app's node_modules path.
+      const { PrismaClient } = await import(prismaClientPath)
 
       // eslint-disable-next-line
       new PrismaClient()

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -48,7 +48,7 @@ export const generatePrismaClient = async ({
         getPaths().base,
         'node_modules/.prisma/client/index.js',
       )
-      console.log(`Prisma client path: ${prismaClientPath}`)
+      console.log('Prisma client path', prismaClientPath)
 
       // Import the client from the Redmix app's node_modules path.
       const { PrismaClient } = await import(prismaClientPath)

--- a/tasks/e2e-background-jobs/run.mts
+++ b/tasks/e2e-background-jobs/run.mts
@@ -112,7 +112,8 @@ async function main() {
     }
     console.log('Confirmed: prisma model exists')
   } catch (error) {
-    console.error('Failed to parse prisma script output')
+    console.error('Error: Failed to parse prisma script output')
+    console.error(prismaData)
     console.error(error?.toString())
     process.exit(1)
   }

--- a/tasks/e2e-background-jobs/run.mts
+++ b/tasks/e2e-background-jobs/run.mts
@@ -222,13 +222,14 @@ async function main() {
   // Step 10: Confirm the job was scheduled into the database
   console.log('Testing: Confirming the job was scheduled into the database')
   const rawJobs = (await $`yarn rw exec jobs --silent`).toString()
+  let job = undefined
   try {
-    const jobs = JSON.parse(rawJobs)
+    const jobs = JSON.parse(rawJobs.split('\n').slice(1).join('\n'))
     if (!jobs?.length) {
       console.error('Expected job not found in the database')
       process.exit(1)
     }
-    const job = jobs[0]
+    job = jobs[0]
     const handler = JSON.parse(job?.handler ?? '{}')
     const args = handler.args ?? []
     if (args[0] !== location || args[1] !== data) {
@@ -280,7 +281,7 @@ async function main() {
   // Step 13: Confirm the job was removed from the database
   console.log('Testing: Confirming the job was removed from the database')
   const rawJobsAfter = (await $`yarn rw exec jobs --silent`).toString()
-  const jobsAfter = JSON.parse(rawJobsAfter)
+  const jobsAfter = JSON.parse(rawJobsAfter.split('\n').slice(1).join('\n'))
   const jobAfter = jobsAfter.find((j: any) => j.id === job.id)
   if (jobAfter) {
     console.error('Expected job found in the database')

--- a/tasks/e2e-background-jobs/run.mts
+++ b/tasks/e2e-background-jobs/run.mts
@@ -104,19 +104,27 @@ async function main() {
 
   console.log('Testing: the prisma model exists in the database')
   const prismaData = (await $`yarn rw exec prisma --silent`).toString()
-  try {
-    const { name } = JSON.parse(prismaData)
-    if (name !== 'BackgroundJob') {
-      console.error('Expected model not found in the database')
-      process.exit(1)
-    }
-    console.log('Confirmed: prisma model exists')
-  } catch (error) {
-    console.error('Error: Failed to parse prisma script output')
-    console.error(prismaData)
-    console.error(error?.toString())
+  console.log('')
+  console.log('prismaData')
+  console.log(prismaData)
+  console.log('')
+  if (!prismaData.includes('{"name":"BackgroundJob"}')) {
+    console.error('Expected model not found in the database')
     process.exit(1)
   }
+  // try {
+  //   const { name } = JSON.parse(prismaData)
+  //   if (name !== 'BackgroundJob') {
+  //     console.error('Expected model not found in the database')
+  //     process.exit(1)
+  //   }
+  //   console.log('Confirmed: prisma model exists')
+  // } catch (error) {
+  //   console.error('Error: Failed to parse prisma script output')
+  //   console.error(prismaData)
+  //   console.error(error?.toString())
+  //   process.exit(1)
+  // }
 
   // Step 3: Generate a job
   console.log('Testing: `yarn rw generate job SampleJob`')

--- a/tasks/e2e-background-jobs/run.mts
+++ b/tasks/e2e-background-jobs/run.mts
@@ -104,12 +104,18 @@ async function main() {
 
   console.log('Testing: the prisma model exists in the database')
   const prismaData = (await $`yarn rw exec prisma --silent`).toString()
-  const { name } = JSON.parse(prismaData)
-  if (name !== 'BackgroundJob') {
-    console.error('Expected model not found in the database')
+  try {
+    const { name } = JSON.parse(prismaData)
+    if (name !== 'BackgroundJob') {
+      console.error('Expected model not found in the database')
+      process.exit(1)
+    }
+    console.log('Confirmed: prisma model exists')
+  } catch (error) {
+    console.error('Failed to parse prisma script output')
+    console.error(error?.toString())
     process.exit(1)
   }
-  console.log('Confirmed: prisma model exists')
 
   // Step 3: Generate a job
   console.log('Testing: `yarn rw generate job SampleJob`')


### PR DESCRIPTION
Use `await import` when getting the Prisma client instead of `require` to make the code ready for ESM.

I'm marking this as a feature because I'm a little worried about how this works together with Babel.

Also of note is I had to add code to clear our require cache. Which is a good sign as far as Babel support for this code goes (because Babel works with `require()`). But also makes it more difficult to actually make this code ESM ready, since ESM doesn't use require (and so, also doesn't use the require cache)