### PR TITLE
chore(babel-config): Use types from @babel/register

### DIFF
--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -48,6 +48,7 @@
     "@redmix/framework-tools": "workspace:*",
     "@types/babel-plugin-tester": "9.0.10",
     "@types/babel__core": "7.20.5",
+    "@types/babel__register": "^7.17.3",
     "@types/node": "20.17.10",
     "babel-plugin-tester": "11.0.4",
     "tsx": "4.19.3",

--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import type { PluginItem, PluginOptions, TransformOptions } from '@babel/core'
+import type { RegisterOptions } from '@babel/register'
 import { parseConfigFileTextToJson } from 'typescript'
 
 import { getPaths } from '@redmix/project-config'
@@ -21,7 +22,8 @@ export interface RegisterHookOptions {
   options?: WebFlags
 }
 
-interface BabelRegisterOptions extends TransformOptions {
+/** @deprecated Please use `RegisterOptions` from `@babel/register` */
+export interface BabelRegisterOptions extends TransformOptions {
   extensions?: string[]
   cache?: boolean
 }
@@ -33,7 +35,7 @@ interface BabelRegisterOptions extends TransformOptions {
 //
 // Lets say we use the import syntax:
 // `import babelRequireHook from '@babel/register'`
-// - if your import in a JS file (like we used to in the cli project) - not a
+// - if you import in a JS file (like we used to in the cli project) - not a
 //   problem, and it would only invoke the register function when you called
 //   babelRequireHook
 // - if you import in a TS file, the transpile process modifies it when we build
@@ -42,11 +44,12 @@ interface BabelRegisterOptions extends TransformOptions {
 //   BUTTT!!! you won't notice it if your project is TS because by default it
 //   ignores .ts and .tsx files, but if its a JS project, it would try to
 //   transpile twice
-export const registerBabel = (options: BabelRegisterOptions) => {
+export const registerBabel = (options: RegisterOptions) => {
   // One of the ways you can use Babel is through the require hook. The require
   // hook will bind itself to node's require and automatically compile files on
-  // the fly. After this `require` all subsequent files required by node with
-  // the extensions .es6, .es, .jsx, .mjs, and .js will be transformed by Babel.
+  // the fly. After this `require`, all subsequent files required by node with
+  // the extensions .es6, .es, .jsx, .mjs, and .js will be transformed by Babel
+  // (unless options.extensions override the default exensions).
   require('@babel/register')(options)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7971,6 +7971,7 @@ __metadata:
     "@redmix/project-config": "workspace:*"
     "@types/babel-plugin-tester": "npm:9.0.10"
     "@types/babel__core": "npm:7.20.5"
+    "@types/babel__register": "npm:^7.17.3"
     "@types/node": "npm:20.17.10"
     babel-plugin-auto-import: "npm:1.1.0"
     babel-plugin-graphql-tag: "npm:3.3.0"
@@ -10656,6 +10657,15 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.0.0"
   checksum: 10c0/f0ba105e7d2296bf367d6e055bb22996886c114261e2cb70bf9359556d0076c7a57239d019dee42bb063f565bade5ccb46009bce2044b2952d964bf9a454d6d2
+  languageName: node
+  linkType: hard
+
+"@types/babel__register@npm:^7.17.3":
+  version: 7.17.3
+  resolution: "@types/babel__register@npm:7.17.3"
+  dependencies:
+    "@types/babel__core": "npm:*"
+  checksum: 10c0/942222432b199ccc4e2689ec697e1cf4ea86a1c525af3b91cdfcadf78acc550bd539d242c718f7a9657ca67ce8f368aa3283cbbecbeaa24fc79917968c7925d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Prefer DefinitelyTyped types to our own. The DT types also provide some extra JSDoc comments that are nice to have.

With this PR I deprecate our own `BabelRegisterOptions` type that's exported from `@redmix/cli`. No one should be importing from here, but potentially they could be doing so. So I've marked it deprecated rather than removing it for now. If someone *is* using our type, they should just import from the same DT package as we are.