### PR TITLE
fix(cli): Import from api-server using .js

### DIFF
--- a/packages/api-server/src/bin.ts
+++ b/packages/api-server/src/bin.ts
@@ -15,7 +15,7 @@ import {
   description as apiDescription,
   builder as apiBuilder,
 } from './apiCLIConfig'
-import { handler as apiHandler } from './apiCLIConfigHandler'
+import { handler as apiHandler } from './apiCLIConfigHandler.js'
 import {
   description as bothDescription,
   builder as bothBuilder,

--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -3,7 +3,7 @@ import path from 'path'
 import concurrently from 'concurrently'
 import execa from 'execa'
 
-import { handler as apiServerHandler } from '@redmix/api-server/dist/apiCLIConfigHandler'
+import { handler as apiServerHandler } from '@redmix/api-server/dist/apiCLIConfigHandler.js'
 import {
   getAPIHost,
   getAPIPort,


### PR DESCRIPTION
Found a couple of imports that still needed a `.js` extension now that the cli is ESM. Only noticed it after another PR triggered our Streaming and RSC CI workflows