### PR TITLE
fix(api): Fix creation of customRequire

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -16,7 +16,10 @@ const customRequire =
     ? require
     : // The argument to `createRequire` should be a file and node will strip
       // the last segment (the file name) to get to a base path. By appending a
-      // fake "foo" file we get the base path we want
+      // fake "foo" file we get the base path we want.
+      // If I knew this was only going to be run as an ESM I'd use
+      // `import.meta.url`, but for dual bundling I can't do that (without a
+      // bunch of warnings at build time at least)
       createRequire(path.join(process.env.RWJS_CWD || process.cwd(), 'foo'))
 
 const rxApiPath = customRequire.resolve('@redmix/api')

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import path from 'node:path'
 
 export * from './auth/index.js'
 export * from './errors.js'
@@ -10,9 +11,13 @@ export * from './cors.js'
 export * from './event.js'
 
 const customRequire =
-  typeof require === 'function'
+  // Look out for a stubbed require function
+  typeof require === 'function' && !require.toString().includes('@rollup')
     ? require
-    : createRequire(process.env.RWJS_CWD || process.cwd())
+    : // The argument to `createRequire` should be a file and node will strip
+      // the last segment (the file name) to get to a base path. By appending a
+      // fake "foo" file we get the base path we want
+      createRequire(path.join(process.env.RWJS_CWD || process.cwd(), 'foo'))
 
 const rxApiPath = customRequire.resolve('@redmix/api')
 const rxApiRequire = createRequire(rxApiPath)


### PR DESCRIPTION
From the comment in the code:

```
      // The argument to `createRequire` should be a file and node will strip
      // the last segment (the file name) to get to a base path. By appending a
      // fake "foo" file we get the base path we want
      // If I knew this was only going to be run as an ESM I'd use
      // `import.meta.url`, but for dual bundling I can't do that (without a
      // bunch of warnings at build time at least)
```