### PR TITLE
chore(test-project): RSC: Use published `@redmix` package versions

### DIFF
--- a/__fixtures__/rsc-caching/api/package.json
+++ b/__fixtures__/rsc-caching/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redmix/api": "8.0.0-canary.1102",
-    "@redmix/graphql-server": "8.0.0-canary.1102"
+    "@redmix/api": "9.0.0-canary.613",
+    "@redmix/graphql-server": "9.0.0-canary.613"
   }
 }

--- a/__fixtures__/rsc-caching/package.json
+++ b/__fixtures__/rsc-caching/package.json
@@ -7,8 +7,8 @@
     ]
   },
   "devDependencies": {
-    "@redmix/core": "8.0.0-canary.1102",
-    "@redmix/project-config": "8.0.0-canary.1102"
+    "@redmix/core": "9.0.0-canary.613",
+    "@redmix/project-config": "9.0.0-canary.613"
   },
   "eslintConfig": {
     "extends": "@redmix/eslint-config",

--- a/__fixtures__/rsc-caching/web/package.json
+++ b/__fixtures__/rsc-caching/web/package.json
@@ -13,18 +13,18 @@
   "dependencies": {
     "@apollo/client-react-streaming": "0.10.0",
     "@jtoar/throw-on-client": "0.0.1",
-    "@redmix/auth-dbauth-middleware": "8.0.0-canary.1102",
-    "@redmix/auth-dbauth-web": "8.0.0-canary.1102",
-    "@redmix/forms": "8.0.0-canary.1102",
-    "@redmix/router": "8.0.0-canary.1102",
-    "@redmix/web": "8.0.0-canary.1102",
+    "@redmix/auth-dbauth-middleware": "9.0.0-canary.613",
+    "@redmix/auth-dbauth-web": "9.0.0-canary.613",
+    "@redmix/forms": "9.0.0-canary.613",
+    "@redmix/router": "9.0.0-canary.613",
+    "@redmix/web": "9.0.0-canary.613",
     "@tobbe.dev/rsc-test": "0.0.5",
     "client-only": "0.0.1",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916"
   },
   "devDependencies": {
-    "@redmix/vite": "8.0.0-canary.1102",
+    "@redmix/vite": "9.0.0-canary.613",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/__fixtures__/test-project-rsa/api/package.json
+++ b/__fixtures__/test-project-rsa/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redmix/api": "8.0.0-canary.144",
-    "@redmix/graphql-server": "8.0.0-canary.144"
+    "@redmix/api": "9.0.0-canary.613",
+    "@redmix/graphql-server": "9.0.0-canary.613"
   }
 }

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "devDependencies": {
-    "@redmix/core": "8.0.0-canary.144"
+    "@redmix/core": "9.0.0-canary.613"
   },
   "eslintConfig": {
     "extends": "@redmix/eslint-config",

--- a/__fixtures__/test-project-rsa/web/package.json
+++ b/__fixtures__/test-project-rsa/web/package.json
@@ -12,14 +12,14 @@
   },
   "dependencies": {
     "@apollo/client-react-streaming": "0.10.0",
-    "@redmix/forms": "8.0.0-canary.144",
-    "@redmix/router": "8.0.0-canary.144",
-    "@redmix/web": "8.0.0-canary.144",
+    "@redmix/forms": "9.0.0-canary.613",
+    "@redmix/router": "9.0.0-canary.613",
+    "@redmix/web": "9.0.0-canary.613",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916"
   },
   "devDependencies": {
-    "@redmix/vite": "8.0.0-canary.144",
+    "@redmix/vite": "9.0.0-canary.613",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/__fixtures__/test-project-rsc-kitchen-sink/api/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redmix/api": "8.0.0-canary.861",
-    "@redmix/graphql-server": "8.0.0-canary.861"
+    "@redmix/api": "9.0.0-canary.613",
+    "@redmix/graphql-server": "9.0.0-canary.613"
   }
 }

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -7,8 +7,8 @@
     ]
   },
   "devDependencies": {
-    "@redmix/core": "8.0.0-canary.861",
-    "@redmix/project-config": "8.0.0-canary.861"
+    "@redmix/core": "9.0.0-canary.613",
+    "@redmix/project-config": "9.0.0-canary.613"
   },
   "eslintConfig": {
     "extends": "@redmix/eslint-config",

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/package.json
@@ -13,18 +13,18 @@
   "dependencies": {
     "@apollo/client-react-streaming": "0.10.0",
     "@jtoar/throw-on-client": "0.0.1",
-    "@redmix/auth-dbauth-middleware": "8.0.0-canary.861",
-    "@redmix/auth-dbauth-web": "8.0.0-canary.861",
-    "@redmix/forms": "8.0.0-canary.861",
-    "@redmix/router": "8.0.0-canary.861",
-    "@redmix/web": "8.0.0-canary.861",
+    "@redmix/auth-dbauth-middleware": "9.0.0-canary.613",
+    "@redmix/auth-dbauth-web": "9.0.0-canary.613",
+    "@redmix/forms": "9.0.0-canary.613",
+    "@redmix/router": "9.0.0-canary.613",
+    "@redmix/web": "9.0.0-canary.613",
     "@tobbe.dev/rsc-test": "0.0.5",
     "client-only": "0.0.1",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916"
   },
   "devDependencies": {
-    "@redmix/vite": "8.0.0-canary.861",
+    "@redmix/vite": "9.0.0-canary.613",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }


### PR DESCRIPTION
The code was previously using Redmix package names, but Redwood package versions. Now it's using Redmix package versions that actually exists (i.e. published to npm)