### PR TITLE
fix(api): Work around Rollup transforms messing with the code

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,7 +12,8 @@ export * from './event.js'
 
 const customRequire =
   // Look out for a stubbed require function
-  typeof require === 'function' && !require.toString().includes('@rollup')
+  // @ts-expect-error - Using `0, ` to work around bundler magic
+  typeof require === 'function' && !(0, require).toString().includes('@rollup')
     ? require
     : // The argument to `createRequire` should be a file and node will strip
       // the last segment (the file name) to get to a base path. By appending a


### PR DESCRIPTION
Doing this:
`typeof require === 'function' && !require.toString().includes('@rollup') ? require`

Rollup would transform that to:
`typeof commonjsRequire === "function" && !require.toString().includes("@rollup") ? commonjsRequire`

And running that you'd get an error saying "ReferenceError: require is not defined in ES module scope, you can use import instead". By doing `(0, require)`, Rollup realizes that it's the global `require` we're working with, so it gets the same treatment as the other `require`s.