### PR TITLE
chore(deps): Bump core-js to 3.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-plugin-remove-code": "0.0.6",
     "boxen": "5.1.2",
     "concurrently": "8.2.2",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "cross-env": "7.0.3",
     "cypress": "13.15.0",
     "cypress-fail-fast": "7.1.1",

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -28,7 +28,7 @@
     "@prisma/internals": "5.20.0",
     "@redmix/cli-helpers": "workspace:*",
     "@simplewebauthn/browser": "9.0.1",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "prompts": "2.4.2",
     "terminal-link": "2.1.1"
   },

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -27,7 +27,7 @@
     "@babel/runtime-corejs3": "7.26.10",
     "@redmix/auth": "workspace:*",
     "@simplewebauthn/browser": "9.0.1",
-    "core-js": "3.38.1"
+    "core-js": "3.42.0"
   },
   "devDependencies": {
     "@babel/cli": "7.26.4",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -87,7 +87,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "react": "19.0.0-rc-f2df5694-20240916"
   },
   "devDependencies": {

--- a/packages/babel-config/dist.test.ts
+++ b/packages/babel-config/dist.test.ts
@@ -15,7 +15,7 @@ describe('dist', () => {
           },
           "version": "7.26.10",
         },
-        "CORE_JS_VERSION": "3.38",
+        "CORE_JS_VERSION": "3.42",
         "RUNTIME_CORE_JS_VERSION": "7.26.10",
         "TARGETS_NODE": "20.10",
         "getApiSideBabelConfigPath": [Function],

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -39,7 +39,7 @@
     "babel-plugin-auto-import": "1.1.0",
     "babel-plugin-graphql-tag": "3.3.0",
     "babel-plugin-module-resolver": "5.0.2",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "fast-glob": "3.3.2",
     "graphql": "16.9.0",
     "typescript": "5.6.2"

--- a/packages/babel-config/src/__tests__/api.test.ts
+++ b/packages/babel-config/src/__tests__/api.test.ts
@@ -59,7 +59,7 @@ describe('api', () => {
             {
               "corejs": {
                 "proposals": true,
-                "version": "3.38",
+                "version": "3.42",
               },
               "exclude": [
                 "@babel/plugin-transform-class-properties",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "ci-info": "4.0.0",
     "concurrently": "8.2.2",
     "configstore": "7.0.0",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "cross-env": "7.0.3",
     "decamelize": "6.0.0",
     "dotenv-defaults": "5.0.2",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -36,7 +36,7 @@
     "@vscode/ripgrep": "1.15.9",
     "@whatwg-node/fetch": "0.9.21",
     "cheerio": "1.0.0",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "deepmerge": "4.3.1",
     "execa": "5.1.1",
     "fast-glob": "3.3.2",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/api": "1.8.0",
     "@redmix/api": "workspace:*",
     "@redmix/context": "workspace:*",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "graphql": "16.9.0",
     "graphql-scalars": "1.23.0",
     "graphql-tag": "2.12.6",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -98,7 +98,7 @@
     "@redmix/router": "workspace:*",
     "@sdl-codegen/node": "2.0.1",
     "chalk": "4.1.2",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "deepmerge": "4.3.1",
     "esbuild": "0.25.0",
     "fast-glob": "3.3.2",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -97,7 +97,7 @@
     "@babel/runtime-corejs3": "7.26.10",
     "@redmix/auth": "workspace:*",
     "@redmix/server-store": "workspace:*",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916",
     "react-server-dom-webpack": "19.0.0-rc-f2df5694-20240916"

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -30,7 +30,7 @@
     "@redmix/project-config": "workspace:*",
     "@types/line-column": "1.0.2",
     "camelcase": "6.3.0",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "deepmerge": "4.3.1",
     "dotenv-defaults": "5.0.2",
     "enquirer": "2.4.1",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -74,7 +74,7 @@
     "buffer": "6.0.3",
     "busboy": "^1.6.0",
     "cookie": "1.0.2",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "dotenv-defaults": "5.0.2",
     "execa": "5.1.1",
     "express": "4.21.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -148,7 +148,7 @@
     "@whatwg-node/fetch": "0.9.21",
     "apollo-upload-client": "18.0.1",
     "cookie": "1.0.2",
-    "core-js": "3.38.1",
+    "core-js": "3.42.0",
     "graphql": "16.9.0",
     "graphql-sse": "2.5.3",
     "graphql-tag": "2.12.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14598,17 +14598,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:3.42.0":
+"core-js@npm:3.42.0, core-js@npm:^3.27.2, core-js@npm:^3.30.2":
   version: 3.42.0
   resolution: "core-js@npm:3.42.0"
   checksum: 10c0/2913d3d5452d54ad92f058d66046782d608c05e037bcc523aab79c04454fe640998f94e6011292969d66dfa472f398b085ce843dcb362056532a5799c627184e
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^3.27.2, core-js@npm:^3.30.2":
-  version: 3.38.1
-  resolution: "core-js@npm:3.38.1"
-  checksum: 10c0/7df063b6f13a54e46515817ac3e235c6c598a4d3de65cd188a061fc250642be313b895fb9fb2f36e1e31890a1bb4ef61d82666a340413f540b7ce3c65689739b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7658,7 +7658,7 @@ __metadata:
     "@simplewebauthn/browser": "npm:9.0.1"
     "@simplewebauthn/types": "npm:9.0.1"
     "@types/yargs": "npm:17.0.33"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     prompts: "npm:2.4.2"
     terminal-link: "npm:2.1.1"
     typescript: "npm:5.6.2"
@@ -7677,7 +7677,7 @@ __metadata:
     "@simplewebauthn/browser": "npm:9.0.1"
     "@simplewebauthn/types": "npm:9.0.1"
     "@types/react": "npm:^18.2.55"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     react: "npm:19.0.0-rc-f2df5694-20240916"
     typescript: "npm:5.6.2"
     vitest: "npm:2.1.9"
@@ -7930,7 +7930,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:6.5.0"
     "@testing-library/react": "npm:14.3.1"
     concurrently: "npm:8.2.2"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     msw: "npm:1.3.4"
     publint: "npm:0.3.11"
     react: "npm:19.0.0-rc-f2df5694-20240916"
@@ -7968,7 +7968,7 @@ __metadata:
     babel-plugin-graphql-tag: "npm:3.3.0"
     babel-plugin-module-resolver: "npm:5.0.2"
     babel-plugin-tester: "npm:11.0.4"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     fast-glob: "npm:3.3.2"
     graphql: "npm:16.9.0"
     tsx: "npm:4.19.3"
@@ -8093,7 +8093,7 @@ __metadata:
     ci-info: "npm:4.0.0"
     concurrently: "npm:8.2.2"
     configstore: "npm:7.0.0"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     cross-env: "npm:7.0.3"
     decamelize: "npm:6.0.0"
     dotenv-defaults: "npm:5.0.2"
@@ -8156,7 +8156,7 @@ __metadata:
     "@vscode/ripgrep": "npm:1.15.9"
     "@whatwg-node/fetch": "npm:0.9.21"
     cheerio: "npm:1.0.0"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     deepmerge: "npm:4.3.1"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.2"
@@ -8387,7 +8387,7 @@ __metadata:
     "@types/uuid": "npm:10.0.0"
     "@whatwg-node/fetch": "npm:0.9.21"
     "@whatwg-node/promise-helpers": "npm:^1.3.0"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     graphql: "npm:16.9.0"
     graphql-scalars: "npm:1.23.0"
     graphql-tag: "npm:2.12.6"
@@ -8433,7 +8433,7 @@ __metadata:
     "@types/fs-extra": "npm:11.0.4"
     chalk: "npm:4.1.2"
     concurrently: "npm:8.2.2"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     deepmerge: "npm:4.3.1"
     esbuild: "npm:0.25.0"
     fast-glob: "npm:3.3.2"
@@ -8697,7 +8697,7 @@ __metadata:
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
     concurrently: "npm:8.2.2"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     publint: "npm:0.3.11"
     react: "npm:19.0.0-rc-f2df5694-20240916"
     react-dom: "npm:19.0.0-rc-f2df5694-20240916"
@@ -8764,7 +8764,7 @@ __metadata:
     "@types/node": "npm:20.17.10"
     "@types/vscode": "npm:1.96.0"
     camelcase: "npm:6.3.0"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     deepmerge: "npm:4.3.1"
     dotenv-defaults: "npm:5.0.2"
     enquirer: "npm:2.4.1"
@@ -8890,7 +8890,7 @@ __metadata:
     busboy: "npm:^1.6.0"
     concurrently: "npm:8.2.2"
     cookie: "npm:1.0.2"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     dotenv-defaults: "npm:5.0.2"
     execa: "npm:5.1.1"
     express: "npm:4.21.2"
@@ -8967,7 +8967,7 @@ __metadata:
     apollo-upload-client: "npm:18.0.1"
     concurrently: "npm:8.2.2"
     cookie: "npm:1.0.2"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     graphql: "npm:16.9.0"
     graphql-sse: "npm:2.5.3"
     graphql-tag: "npm:2.12.6"
@@ -14598,7 +14598,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:3.38.1, core-js@npm:^3.27.2, core-js@npm:^3.30.2":
+"core-js@npm:3.42.0":
+  version: 3.42.0
+  resolution: "core-js@npm:3.42.0"
+  checksum: 10c0/2913d3d5452d54ad92f058d66046782d608c05e037bcc523aab79c04454fe640998f94e6011292969d66dfa472f398b085ce843dcb362056532a5799c627184e
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.27.2, core-js@npm:^3.30.2":
   version: 3.38.1
   resolution: "core-js@npm:3.38.1"
   checksum: 10c0/7df063b6f13a54e46515817ac3e235c6c598a4d3de65cd188a061fc250642be313b895fb9fb2f36e1e31890a1bb4ef61d82666a340413f540b7ce3c65689739b
@@ -26573,7 +26580,7 @@ __metadata:
     babel-plugin-remove-code: "npm:0.0.6"
     boxen: "npm:5.1.2"
     concurrently: "npm:8.2.2"
-    core-js: "npm:3.38.1"
+    core-js: "npm:3.42.0"
     cross-env: "npm:7.0.3"
     cypress: "npm:13.15.0"
     cypress-fail-fast: "npm:7.1.1"


### PR DESCRIPTION
##### [3.42.0 - 2025.04.30](https://github.com/zloirock/core-js/releases/tag/v3.42.0)
- Changes [v3.41.0...v3.42.0](https://github.com/zloirock/core-js/compare/v3.41.0...v3.42.0) (142 commits)
- [`Map` upsert proposal](https://github.com/tc39/proposal-upsert):
  - Moved to stage 2.7, [April 2025 TC39 meeting](https://x.com/robpalmer2/status/1911882240109261148)
  - Validation order of `WeakMap.prototype.getOrInsertComputed` updated following [tc39/proposal-upsert#79](https://github.com/tc39/proposal-upsert/pull/79)
  - Built-ins:
    - `Map.prototype.getOrInsert`
    - `Map.prototype.getOrInsertComputed`
    - `WeakMap.prototype.getOrInsert`
    - `WeakMap.prototype.getOrInsertComputed`
- Don't call well-known `Symbol` methods for `RegExp` on primitive values following [tc39/ecma262#3009](https://github.com/tc39/ecma262/pull/3009):
  - For avoid performance regression, temporarily, only in own `core-js` implementations
  - Built-ins:
    - `String.prototype.matchAll`
    - `String.prototype.match`
    - `String.prototype.replaceAll`
    - `String.prototype.replace`
    - `String.prototype.search`
    - `String.prototype.split`
- Added workaround for the [`Uint8Array.prototype.setFromBase64`](https://github.com/tc39/proposal-arraybuffer-base64) [bug](https://bugs.webkit.org/show_bug.cgi?id=290829) in some of Linux builds of WebKit
- Implemented early-error iterator closing following [tc39/ecma262#3467](https://github.com/tc39/ecma262/pull/3467), including fix of [a WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=291195), in the following methods:
  - `Iterator.prototype.drop`
  - `Iterator.prototype.every`
  - `Iterator.prototype.filter`
  - `Iterator.prototype.find`
  - `Iterator.prototype.flatMap`
  - `Iterator.prototype.forEach`
  - `Iterator.prototype.map`
  - `Iterator.prototype.reduce`
  - `Iterator.prototype.some`
  - `Iterator.prototype.take`
- Fixed missing forced replacement of [`AsyncIterator` helpers](https://github.com/tc39/proposal-async-iterator-helpers)
- Added closing of sync iterator when async wrapper yields a rejection following [tc39/ecma262#2600](https://github.com/tc39/ecma262/pull/2600). Affected methods:
  - [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) (due to the lack of async feature detection capability - temporarily, only in own `core-js` implementation)
  - [`AsyncIterator.from`](https://github.com/tc39/proposal-async-iterator-helpers)
  - [`Iterator.prototype.toAsync`](https://github.com/tc39/proposal-async-iterator-helpers)
- Added detection for throwing on `undefined` initial parameter in `Iterator.prototype.reduce` (see [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=291651))
- `core-js-compat` and `core-js-builder` API:
  - Added `'intersect'` support for `targets.esmodules` (Babel 7 behavior)
  - Fixed handling of `targets.esmodules: true` (Babel 7 behavior)
- Compat data improvements:
  - [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) features disabled (again) in V8 ~ Chromium 135 and re-added in 136
  - [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) marked as [shipped from V8 ~ Chromium 136](https://issues.chromium.org/issues/353856236#comment17)
  - [`Error.isError`](https://github.com/tc39/proposal-is-error) marked as [shipped from FF138](https://bugzilla.mozilla.org/show_bug.cgi?id=1952249)
  - [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) features re-enabled in [Deno 2.2.10](https://github.com/denoland/deno/releases/tag/v2.2.10)
  - [`Iterator` helpers proposal](https://github.com/tc39/proposal-iterator-helpers) features marked as supported from Deno 1.38.1 since it seems they were disabled in 1.38.0
  - `Iterator.prototype.{ drop, reduce, take }` methods marked as fixed in Bun 1.2.11
  - Added [NodeJS 24.0](https://github.com/nodejs/node/pull/57609) compat data mapping
  - Updated Electron 36 and added Electron 37 compat data mapping
  - Added Opera Android [88](https://forums.opera.com/topic/83800/opera-for-android-88) and [89](https://forums.opera.com/topic/84437/opera-for-android-89) compat data mapping
  - Added Oculus Quest Browser 37 compat data mapping

##### [3.41.0 - 2025.03.01](https://github.com/zloirock/core-js/releases/tag/v3.41.0)
- Changes [v3.40.0...v3.41.0](https://github.com/zloirock/core-js/compare/v3.40.0...v3.41.0) (85 commits)
- [`RegExp.escape` proposal](https://github.com/tc39/proposal-regex-escaping):
  - Built-ins:
    - `RegExp.escape`
  - Moved to stable ES, [February 2025 TC39 meeting](https://github.com/tc39/proposals/commit/b81fa9bccf4b51f33de0cbe797976a84d05d4b76)
  - Added `es.` namespace module, `/es/` and `/stable/` namespaces entries
- [`Float16` proposal](https://github.com/tc39/proposal-float16array):
  - Built-ins:
    - `Math.f16round`
    - `DataView.prototype.getFloat16`
    - `DataView.prototype.setFloat16`
  - Moved to stable ES, [February 2025 TC39 meeting](https://github.com/tc39/proposals/commit/b81fa9bccf4b51f33de0cbe797976a84d05d4b76)
  - Added `es.` namespace modules, `/es/` and `/stable/` namespaces entries
- [`Math.clamp` stage 1 proposal](https://github.com/CanadaHonk/proposal-math-clamp):
  - Built-ins:
    - `Math.clamp`
  - Extracted from [old `Math` extensions proposal](https://github.com/rwaldron/proposal-math-extensions), [February 2025 TC39 meeting](https://github.com/tc39/proposals/commit/0c24594aab19a50b86d0db7248cac5eb0ae35621)
  - Added arguments validation
  - Added new entries
- Added a workaround of a V8 `AsyncDisposableStack` bug, [tc39/proposal-explicit-resource-management/256](https://github.com/tc39/proposal-explicit-resource-management/issues/256)
- Compat data improvements:
  - [`DisposableStack`, `SuppressedError` and `Iterator.prototype[@@dispose]`](https://github.com/tc39/proposal-explicit-resource-management) marked as [shipped from V8 ~ Chromium 134](https://issues.chromium.org/issues/42203506#comment24)
  - [`Error.isError`](https://github.com/tc39/proposal-is-error) added and marked as [shipped from V8 ~ Chromium 134](https://issues.chromium.org/issues/382104870#comment4)
  - [`Math.f16round` and `DataView.prototype.{ getFloat16, setFloat16 }`](https://github.com/tc39/proposal-float16array) marked as [shipped from V8 ~ Chromium 135](https://issues.chromium.org/issues/42203953#comment36)
  - [`Iterator` helpers proposal](https://github.com/tc39/proposal-iterator-helpers) features marked as [shipped from Safari 18.4](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#New-Features)
  - [`JSON.parse` source text access proposal](https://github.com/tc39/proposal-json-parse-with-source) features marked as [shipped from Safari 18.4](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#New-Features)
  - [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) marked as shipped from FF137
  - Added [Deno 2.2](https://github.com/denoland/deno/releases/tag/v2.2.0) compat data and compat data mapping
    - Explicit Resource Management features are available in V8 ~ Chromium 134, but not in Deno 2.2 based on it
  - Updated Electron 35 and added Electron 36 compat data mapping
  - Updated [Opera Android 87](https://forums.opera.com/topic/75836/opera-for-android-87) compat data mapping
  - Added Samsung Internet 28 compat data mapping
  - Added Oculus Quest Browser 36 compat data mapping

##### [3.40.0 - 2025.01.08](https://github.com/zloirock/core-js/releases/tag/v3.40.0)
- Changes [v3.39.0...v3.40.0](https://github.com/zloirock/core-js/compare/v3.39.0...v3.40.0) (130 commits)
- Added [`Error.isError` stage 3 proposal](https://github.com/tc39/proposal-is-error):
  - Added built-ins:
    - `Error.isError`
  - We have no bulletproof way to polyfill this method / check if the object is an error, so it's an enough naive implementation that is marked as `.sham`
- [Explicit Resource Management stage 3 proposal](https://github.com/tc39/proposal-explicit-resource-management):
  - Updated the way async disposing of only sync disposable resources, [tc39/proposal-explicit-resource-management/218](https://github.com/tc39/proposal-explicit-resource-management/pull/218)
- [`Iterator` sequencing stage 2.7 proposal](https://github.com/tc39/proposal-iterator-sequencing):
  - Reuse `IteratorResult` objects when possible, [tc39/proposal-iterator-sequencing/17](https://github.com/tc39/proposal-iterator-sequencing/issues/17), [tc39/proposal-iterator-sequencing/18](https://github.com/tc39/proposal-iterator-sequencing/pull/18), December 2024 TC39 meeting
- Added a fix of [V8 < 12.8](https://issues.chromium.org/issues/351332634) / [NodeJS < 22.10](https://github.com/nodejs/node/pull/54883) bug with handling infinite length of set-like objects in `Set` methods
- Optimized `DataView.prototype.{ getFloat16, setFloat16 }` performance, [#1379](https://github.com/zloirock/core-js/pull/1379), thanks [**@LeviPesin**](https://github.com/LeviPesin)
- Dropped unneeded feature detection of non-standard `%TypedArray%.prototype.toSpliced`
- Dropped possible re-usage of some non-standard / early stage features (like `Math.scale`) available on global
- Some other minor improvements
- Compat data improvements:
  - [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) marked as shipped from Safari 18.2
  - [`Promise.try`](https://github.com/tc39/proposal-promise-try) marked as shipped from Safari 18.2
  - [`Math.f16round` and `DataView.prototype.{ getFloat16, setFloat16 }`](https://github.com/tc39/proposal-float16array) marked as shipped from Safari 18.2
  - [`Uint8Array` to / from base64 and hex proposal](https://github.com/tc39/proposal-arraybuffer-base64) methods marked as shipped from Safari 18.2
  - [`JSON.parse` source text access proposal](https://github.com/tc39/proposal-json-parse-with-source) features marked as [shipped from FF135](https://bugzilla.mozilla.org/show_bug.cgi?id=1934622)
  - [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) marked as shipped [from FF134](https://bugzilla.mozilla.org/show_bug.cgi?id=1918235)
  - [`Promise.try`](https://github.com/tc39/proposal-promise-try) marked as shipped from FF134
  - [`Symbol.dispose`, `Symbol.asyncDispose` and `Iterator.prototype[@@dispose]`](https://github.com/tc39/proposal-explicit-resource-management) marked as shipped from FF135
  - [`JSON.parse` source text access proposal](https://github.com/tc39/proposal-json-parse-with-source) features marked as shipped from Bun 1.1.43
  - Fixed NodeJS version where `URL.parse` was added - 22.1 instead of 22.0
  - Added [Deno 2.1](https://github.com/denoland/deno/releases/tag/v2.1.0) compat data mapping
  - Added [Rhino 1.8.0](https://github.com/mozilla/rhino/releases/tag/Rhino1_8_0_Release) compat data with significant number of modern features
  - Added Electron 35 compat data mapping
  - Updated Opera 115+ compat data mapping
  - Added Opera Android [86](https://forums.opera.com/topic/75006/opera-for-android-86) and 87 compat data mapping

##### [3.39.0 - 2024.10.31](https://github.com/zloirock/core-js/releases/tag/v3.39.0)
- Changes [v3.38.1...v3.39.0](https://github.com/zloirock/core-js/compare/v3.38.1...v3.39.0)
- [`Iterator` helpers proposal](https://github.com/tc39/proposal-iterator-helpers):
  - Built-ins:
    - `Iterator`
      - `Iterator.from`
      - `Iterator.prototype.drop`
      - `Iterator.prototype.every`
      - `Iterator.prototype.filter`
      - `Iterator.prototype.find`
      - `Iterator.prototype.flatMap`
      - `Iterator.prototype.forEach`
      - `Iterator.prototype.map`
      - `Iterator.prototype.reduce`
      - `Iterator.prototype.some`
      - `Iterator.prototype.take`
      - `Iterator.prototype.toArray`
      - `Iterator.prototype[@@toStringTag]`
  - Moved to stable ES, [October 2024 TC39 meeting](https://github.com/tc39/proposal-iterator-helpers/issues/284#event-14549961807)
  - Added `es.` namespace modules, `/es/` and `/stable/` namespaces entries
- [`Promise.try`](https://github.com/tc39/proposal-promise-try):
  - Built-ins:
    - `Promise.try`
  - Moved to stable ES, [October 2024 TC39 meeting](https://github.com/tc39/proposal-promise-try/commit/53d3351687274952b3b88f3ad024d9d68a9c1c93)
  - Added `es.` namespace module, `/es/` and `/stable/` namespaces entries
  - Fixed `/actual|full/promise/try` entries for the callback arguments support
- [`Math.sumPrecise` proposal](https://github.com/tc39/proposal-math-sum):
  - Built-ins:
    - `Math.sumPrecise`
  - Moved to stage 3, [October 2024 TC39 meeting](https://github.com/tc39/proposal-math-sum/issues/19)
  - Added `/actual/` namespace entries, unconditional forced replacement changed to feature detection
- Added [`Iterator` sequencing stage 2.7 proposal](https://github.com/tc39/proposal-iterator-sequencing):
  - Added built-ins:
    - `Iterator.concat`
- [`Map` upsert stage 2 proposal](https://github.com/tc39/proposal-upsert):
  - [Updated to the new API following the October 2024 TC39 meeting](https://github.com/tc39/proposal-upsert/pull/58)
  - Added built-ins:
    - `Map.prototype.getOrInsert`
    - `Map.prototype.getOrInsertComputed`
    - `WeakMap.prototype.getOrInsert`
    - `WeakMap.prototype.getOrInsertComputed`
- [Extractors proposal](https://github.com/tc39/proposal-extractors) moved to stage 2, [October 2024 TC39 meeting](https://github.com/tc39/proposals/commit/11bc489049fc5ce59b21e98a670a84f153a29a80)
- Usage of `@@species` pattern removed from `%TypedArray%` and `ArrayBuffer` methods, [tc39/ecma262/3450](https://github.com/tc39/ecma262/pull/3450):
  - Built-ins:
    - `%TypedArray%.prototype.filter`
    - `%TypedArray%.prototype.filterReject`
    - `%TypedArray%.prototype.map`
    - `%TypedArray%.prototype.slice`
    - `%TypedArray%.prototype.subarray`
    - `ArrayBuffer.prototype.slice`
- Some other minor improvements
- Compat data improvements:
  - [`Uint8Array` to / from base64 and hex proposal](https://github.com/tc39/proposal-arraybuffer-base64) methods marked as [shipped from FF133](https://bugzilla.mozilla.org/show_bug.cgi?id=1917885#c9)
  - Added [NodeJS 23.0](https://nodejs.org/en/blog/release/v23.0.0) compat data mapping
  - `self` descriptor [is fixed](https://github.com/denoland/deno/issues/24683) in Deno 1.46.0
  - Added Deno [1.46](https://github.com/denoland/deno/releases/tag/v1.46.0) and [2.0](https://github.com/denoland/deno/releases/tag/v2.0.0) compat data mapping
  - [`Iterator` helpers proposal](https://github.com/tc39/proposal-iterator-helpers) methods marked as [shipped from Bun 1.1.31](https://github.com/oven-sh/bun/pull/14455)
  - Added Electron 34 and updated Electron 33 compat data mapping
  - Added [Opera Android 85](https://forums.opera.com/topic/74256/opera-for-android-85) compat data mapping
  - Added Oculus Quest Browser 35 compat data mapping