### PR TITLE
fix(context): Add .js to export for ESM compatibility

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/cjs/store.d.ts",
         "default": "./dist/cjs/store.js"
       }
+    },
+    "./dist/store.js": {
+      "import": {
+        "types": "./dist/store.d.ts",
+        "default": "./dist/store.js"
+      },
+      "default": {
+        "types": "./dist/cjs/store.d.ts",
+        "default": "./dist/cjs/store.js"
+      }
     }
   },
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
Fixing this error I got when trying to switch a Redmix project over to ESM:

```
api |
api | Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/store.js' is not defined by "exports" in /Users/tobbe/tmp/rx-esm-1/node_modules/@redmix/context/package.json imported from /Users/tobbe/tmp/rx-esm-1/api/dist/functions/graphql.js
api |     at exportsNotFound (node:internal/modules/esm/resolve:322:10)
api |     at packageExportsResolve (node:internal/modules/esm/resolve:670:9)
api |     at packageResolve (node:internal/modules/esm/resolve:856:14)
api |     at moduleResolve (node:internal/modules/esm/resolve:946:18)
api |     at defaultResolve (node:internal/modules/esm/resolve:1188:11)
api |     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:642:12)
api |     at #cachedDefaultResolve (node:internal/modules/esm/loader:591:25)
api |     at ModuleLoader.resolve (node:internal/modules/esm/loader:574:38)
api |     at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:236:38)
api |     at ModuleJob._link (node:internal/modules/esm/module_job:130:49) {
api |   code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
api | }
^Cweb | yarn cross-env NODE_ENV=development rw-vite-dev  exited with code 0
```