### PR TITLE
fix(api-server): Use --port and --host options

### DIFF
--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -18,7 +18,7 @@ import { getConfig } from '@redmix/project-config'
 import type { createServer as tCreateServer } from '../createServer.js'
 import {
   resolveOptions,
-  DEFAULT_CREATE_SERVER_OPTIONS,
+  getDefaultCreateServerOptions,
 } from '../createServerHelpers'
 
 // Set up RWJS_CWD.
@@ -223,21 +223,28 @@ describe('createServer', () => {
 })
 
 describe('resolveOptions', () => {
-  it('nothing passed', () => {
+  it('uses defaults when no arguments are passed', () => {
     const resolvedOptions = resolveOptions()
+    const defaults = getDefaultCreateServerOptions()
 
     expect(resolvedOptions).toEqual({
-      apiRootPath: DEFAULT_CREATE_SERVER_OPTIONS.apiRootPath,
-      configureApiServer: DEFAULT_CREATE_SERVER_OPTIONS.configureApiServer,
+      apiRootPath: defaults.apiRootPath,
+      // Can't really compare functions with toEqual() unless it's the same
+      // reference. And when calling `getDefaulCreateServerOptions()` you get a
+      // new function, and thus a new reference, each time
+      configureApiServer: resolvedOptions.configureApiServer,
       fastifyServerOptions: {
-        requestTimeout:
-          DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout,
-        logger: DEFAULT_CREATE_SERVER_OPTIONS.logger,
-        bodyLimit: DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.bodyLimit,
+        requestTimeout: defaults.fastifyServerOptions.requestTimeout,
+        logger: defaults.logger,
+        bodyLimit: defaults.fastifyServerOptions.bodyLimit,
       },
-      apiPort: 65501,
       apiHost: '::',
+      apiPort: 65501,
     })
+
+    expect(resolvedOptions.configureApiServer.toString()).toEqual(
+      defaults.configureApiServer.toString(),
+    )
   })
 
   it('ensures `apiRootPath` has slashes', () => {
@@ -300,7 +307,7 @@ describe('resolveOptions', () => {
 
     expect(resolvedOptions).toMatchObject({
       fastifyServerOptions: {
-        logger: DEFAULT_CREATE_SERVER_OPTIONS.logger,
+        logger: getDefaultCreateServerOptions().logger,
       },
     })
   })

--- a/packages/api-server/src/apiCLIConfigHandler.ts
+++ b/packages/api-server/src/apiCLIConfigHandler.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk'
 
 import { coerceRootPath } from '@redmix/fastify-web'
 
-import { getAPIPort, getAPIHost } from './cliHelpers'
 import { createServer } from './createServer'
 import type { APIParsedOptions } from './types'
 
@@ -14,10 +13,9 @@ export async function handler(options: APIParsedOptions = {}) {
 
   const fastify = await createServer({
     apiRootPath: options.apiRootPath,
+    apiHost: options.host,
+    apiPort: options.port,
   })
-
-  options.host ??= getAPIHost()
-  options.port ??= getAPIPort()
 
   await fastify.start()
 

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -34,6 +34,12 @@ export interface CreateServerOptions {
 
   /** Whether to parse args or not. Defaults to `true` */
   parseArgs?: boolean
+
+  /** The port to listen on. Defaults to what's configured in redwood.toml */
+  apiPort?: number
+
+  /** The host to bind to. Defaults to what's configured in redwood.toml */
+  apiHost?: string
 }
 
 type DefaultCreateServerOptions = Required<
@@ -55,13 +61,13 @@ export const DEFAULT_CREATE_SERVER_OPTIONS: DefaultCreateServerOptions = {
   },
   configureApiServer: () => {},
   parseArgs: true,
+  apiHost: getAPIHost(),
+  apiPort: getAPIPort(),
 }
 
 type ResolvedOptions = Required<
   Omit<CreateServerOptions, 'logger' | 'fastifyServerOptions' | 'parseArgs'> & {
     fastifyServerOptions: FastifyServerOptions
-    apiPort: number
-    apiHost: string
   }
 >
 
@@ -87,8 +93,8 @@ export function resolveOptions(
     configureApiServer:
       options.configureApiServer ??
       DEFAULT_CREATE_SERVER_OPTIONS.configureApiServer,
-    apiHost: getAPIHost(),
-    apiPort: getAPIPort(),
+    apiHost: options.apiHost ?? DEFAULT_CREATE_SERVER_OPTIONS.apiHost,
+    apiPort: options.apiPort ?? DEFAULT_CREATE_SERVER_OPTIONS.apiPort,
   }
 
   // Merge fastifyServerOptions.

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -48,22 +48,25 @@ type DefaultCreateServerOptions = Required<
   }
 >
 
-export const DEFAULT_CREATE_SERVER_OPTIONS: DefaultCreateServerOptions = {
-  apiRootPath: '/',
-  logger: {
-    level:
-      process.env.LOG_LEVEL ??
-      (process.env.NODE_ENV === 'development' ? 'debug' : 'warn'),
-  },
-  fastifyServerOptions: {
-    requestTimeout: 15_000,
-    bodyLimit: 1024 * 1024 * 100, // 100MB
-  },
-  configureApiServer: () => {},
-  parseArgs: true,
-  apiHost: getAPIHost(),
-  apiPort: getAPIPort(),
-}
+// This is a function instead of just a constant so that we don't execute
+// getAPIHost and getAPIPort just by importing this file.
+export const getDefaultCreateServerOptions: () => DefaultCreateServerOptions =
+  () => ({
+    apiRootPath: '/',
+    logger: {
+      level:
+        process.env.LOG_LEVEL ??
+        (process.env.NODE_ENV === 'development' ? 'debug' : 'warn'),
+    },
+    fastifyServerOptions: {
+      requestTimeout: 15_000,
+      bodyLimit: 1024 * 1024 * 100, // 100MB
+    },
+    configureApiServer: () => {},
+    parseArgs: true,
+    apiHost: getAPIHost(),
+    apiPort: getAPIPort(),
+  })
 
 type ResolvedOptions = Required<
   Omit<CreateServerOptions, 'logger' | 'fastifyServerOptions' | 'parseArgs'> & {
@@ -77,29 +80,28 @@ export function resolveOptions(
 ) {
   options.parseArgs ??= true
 
-  options.logger ??= DEFAULT_CREATE_SERVER_OPTIONS.logger
+  const defaults = getDefaultCreateServerOptions()
+
+  options.logger ??= defaults.logger
 
   // Set defaults.
   const resolvedOptions: ResolvedOptions = {
-    apiRootPath:
-      options.apiRootPath ?? DEFAULT_CREATE_SERVER_OPTIONS.apiRootPath,
+    apiRootPath: options.apiRootPath ?? defaults.apiRootPath,
 
     fastifyServerOptions: options.fastifyServerOptions ?? {
-      requestTimeout:
-        DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout,
-      logger: options.logger ?? DEFAULT_CREATE_SERVER_OPTIONS.logger,
-      bodyLimit: DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.bodyLimit,
+      requestTimeout: defaults.fastifyServerOptions.requestTimeout,
+      logger: options.logger ?? defaults.logger,
+      bodyLimit: defaults.fastifyServerOptions.bodyLimit,
     },
     configureApiServer:
-      options.configureApiServer ??
-      DEFAULT_CREATE_SERVER_OPTIONS.configureApiServer,
-    apiHost: options.apiHost ?? DEFAULT_CREATE_SERVER_OPTIONS.apiHost,
-    apiPort: options.apiPort ?? DEFAULT_CREATE_SERVER_OPTIONS.apiPort,
+      options.configureApiServer ?? defaults.configureApiServer,
+    apiHost: options.apiHost ?? defaults.apiHost,
+    apiPort: options.apiPort ?? defaults.apiPort,
   }
 
   // Merge fastifyServerOptions.
   resolvedOptions.fastifyServerOptions.requestTimeout ??=
-    DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout
+    defaults.fastifyServerOptions.requestTimeout
   resolvedOptions.fastifyServerOptions.logger = options.logger
 
   if (options.parseArgs) {


### PR DESCRIPTION
The `rw-server` bin was documented to have `--port` and `--host` command line options, but they were never actually used. `-p` would work, but not `--port`. You could configure them both before using env vars, and you still can, but now also the long version of the command line arguments work.